### PR TITLE
feat(mockotlpserver): use diagnostic channels for passing parsed OTLP data to printers

### DIFF
--- a/packages/mockotlpserver/lib/diagch.js
+++ b/packages/mockotlpserver/lib/diagch.js
@@ -1,0 +1,41 @@
+// This file defines the diagnostic channels used by mockotlpserver and
+// some utilities for using them.
+
+const diagnostics_channel = require('diagnostics_channel');
+
+// Keep a references to channels created for `ch.subscribe(name)` to avoid
+// https://github.com/nodejs/node/issues/42170 bug with Node.js <16.17.0.
+const diagchFromName = {};
+
+function diagchGet(name) {
+    if (!(name in diagchFromName)) {
+        diagchFromName[name] = diagnostics_channel.channel(name);
+    }
+    return diagchFromName[name];
+}
+
+function diagchSub(name, onMessage) {
+    if (diagnostics_channel.subscribe) {
+        // `diagnostics_channel.subscribe` was added in Node.js 16.17.0.
+        diagnostics_channel.subscribe(name, onMessage);
+    } else {
+        // Keep ref to avoid https://github.com/nodejs/node/issues/42170 bug.
+        const ch = diagchGet(name);
+        ch.subscribe(onMessage);
+    }
+}
+
+// A diagnostic channel for each
+// `opentelemetry.proto.collector.{signal}.v1.Exports{Signal}ServiceRequest`.
+const CH_OTLP_V1_TRACE = 'otlp.v1.trace';
+const CH_OTLP_V1_METRICS = 'otlp.v1.metrics';
+const CH_OTLP_V1_LOGS = 'otlp.v1.logs';
+
+module.exports = {
+    diagchGet,
+    diagchSub,
+
+    CH_OTLP_V1_TRACE,
+    CH_OTLP_V1_METRICS,
+    CH_OTLP_V1_LOGS,
+};

--- a/packages/mockotlpserver/lib/grpc.js
+++ b/packages/mockotlpserver/lib/grpc.js
@@ -3,6 +3,13 @@ const {resolve} = require('path');
 const grpc = require('@grpc/grpc-js');
 const loader = require('@grpc/proto-loader');
 
+const {
+    diagchGet,
+    CH_OTLP_V1_TRACE,
+    // CH_OTLP_V1_METRICS,
+    // CH_OTLP_V1_LOGS,
+} = require('./diagch');
+
 // TODO: for now `proto` files are copied from
 // https://github.com/open-telemetry/opentelemetry-proto
 // but maybe its better to have a submodule like otel-js does
@@ -27,9 +34,7 @@ for (const [name, path] of Object.entries(packages)) {
 // helper functions
 
 function intakeTraces(call, callback) {
-    const tracesReq = call.request;
-    console.dir(tracesReq, {depth: 9});
-
+    diagchGet(CH_OTLP_V1_TRACE).publish(call.request);
     callback(null, {
         partial_success: {
             rejected_spans: 0,

--- a/packages/mockotlpserver/lib/index.js
+++ b/packages/mockotlpserver/lib/index.js
@@ -1,7 +1,7 @@
 const luggite = require('./luggite');
-
 const {startHttp} = require('./http');
 const {startGrpc} = require('./grpc');
+const {InspectPrinter} = require('./printers');
 
 const log = luggite.createLogger({name: 'mockotlpserver'});
 
@@ -12,7 +12,8 @@ const DEFAULT_HOSTNAME = 'localhost';
 const DEFAULT_HTTP_PORT = 4318;
 const DEFAULT_GRPC_PORT = 4317;
 
-// Start a server which accepts incoming HTTP requests. Exporters supported:
+// Start a server which accepts incoming OTLP/HTTP calls and publishes
+// received request data to the `otlp.*` diagnostic channels.
 // Handles `OTEL_EXPORTER_OTLP_PROTOCOL=http/proto` and
 // `OTEL_EXPORTER_OTLP_PROTOCOL=http/json`.
 startHttp({
@@ -21,12 +22,15 @@ startHttp({
     port: DEFAULT_HTTP_PORT,
 });
 
-// Start a server which accepts incoming GRPC calls.
+// Start a server which accepts incoming OTLP/gRPC calls and publishes
+// received request data to the `otlp.*` diagnostic channels.
 // Handles `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`.
-//
 // NOTE: to debug read this: https://github.com/grpc/grpc-node/blob/master/TROUBLESHOOTING.md
 startGrpc({
     log,
     hostname: DEFAULT_HOSTNAME,
     port: DEFAULT_GRPC_PORT,
 });
+
+const printer = new InspectPrinter();
+printer.subscribe();

--- a/packages/mockotlpserver/lib/printers.js
+++ b/packages/mockotlpserver/lib/printers.js
@@ -1,0 +1,49 @@
+/**
+ * Various "Printers" the subscribe to `otlp.*` diagnostic channels and print
+ * the results in various formats.
+ *
+ * Usage:
+ *      const printer = new InspectPrinter();
+ *      printer.subscribe();
+ */
+
+const {
+    diagchSub,
+    CH_OTLP_V1_LOGS,
+    CH_OTLP_V1_METRICS,
+    CH_OTLP_V1_TRACE,
+} = require('./diagch');
+
+class Printer {
+    subscribe() {
+        if (typeof this.printTrace === 'function') {
+            diagchSub(CH_OTLP_V1_TRACE, this.printTrace.bind(this));
+        }
+        if (typeof this.printMetrics === 'function') {
+            diagchSub(CH_OTLP_V1_METRICS, this.printMetrics.bind(this));
+        }
+        if (typeof this.printLogs === 'function') {
+            diagchSub(CH_OTLP_V1_LOGS, this.printTrace.bind(this));
+        }
+    }
+}
+
+class InspectPrinter extends Printer {
+    constructor() {
+        super();
+        this._inspectOpts = {depth: 9, breakLength: process.stdout.columns};
+    }
+    printTrace(trace) {
+        console.dir(trace, this._inspectOpts);
+    }
+    printMetrics(metrics) {
+        console.dir(metrics, this._inspectOpts);
+    }
+    printLogs(logs) {
+        console.dir(logs, this._inspectOpts);
+    }
+}
+
+module.exports = {
+    InspectPrinter,
+};

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -22,7 +22,7 @@
   ],
   "author": "Elastic Observability <https://www.elastic.co/observability>",
   "engines": {
-    "node": ">=14"
+    "node": ">=14.17.0"
   },
   "scripts": {
     "lint": "eslint --ext=js,mjs,cjs . # requires node >=16.0.0",


### PR DESCRIPTION
The HTTP and gRPC servers will now publish parsed OTLP data to
diagnostics channels named 'otlp.v1.trace', etc.
Then there is a simple Printer class which supports a subclass
with 'printTrace' et al methods. Those will subscribe to the
'otlp.*' channels and print as needed.

Multiple independent subscribers can be added. We can change
the 'Printer' name later if something else make better sense.

Using diagnostics_channel required bumping the min node to 14.17.0.

The only current printer is the InspectPrinter.
