### PR TITLE
chore: fix update-otel-deps, update to OTel release from today

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.45.1.tgz",
-      "integrity": "sha512-zVGq/k70l+kB/Wuv3O/zhptP2hvDhEbhDu9EtHde1iWZJf3FedeYS/nWVcMBkkyPAjS/JKNk86WN4CBQLGUuOw==",
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.47.0.tgz",
+      "integrity": "sha512-AR6UOVcWZkuibLR/7/OecYJasncAf6VstNV/KT5qHq1HShVFmJetcgim0KMog/ON23yHZQjT9GPVTwB0FEhPQA==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -437,55 +437,55 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.40.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.40.2.tgz",
-      "integrity": "sha512-t47g+Vs1V+Vd8HIKfx8D7nbNXSvq1uDceMlWoWzPABhet7iTLFbrPqPakxw2MOru4T0n0phwlC8+/dLfV37QXg==",
+      "version": "0.40.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.40.3.tgz",
+      "integrity": "sha512-MgBCzpFU4FBQEsXPgt5driYzxErf2JGntQ8Amtc94sqrnvq+FKdEBa6vxOpZlPM+c4Xr6tPpAT1ecTBV8U87hw==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
-        "@opentelemetry/instrumentation-amqplib": "^0.33.4",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.37.3",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.37.1",
-        "@opentelemetry/instrumentation-bunyan": "^0.34.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.34.1",
-        "@opentelemetry/instrumentation-connect": "^0.32.3",
-        "@opentelemetry/instrumentation-cucumber": "^0.2.0",
-        "@opentelemetry/instrumentation-dataloader": "^0.5.3",
-        "@opentelemetry/instrumentation-dns": "^0.32.4",
-        "@opentelemetry/instrumentation-express": "^0.34.0",
-        "@opentelemetry/instrumentation-fastify": "^0.32.5",
-        "@opentelemetry/instrumentation-fs": "^0.8.3",
-        "@opentelemetry/instrumentation-generic-pool": "^0.32.4",
-        "@opentelemetry/instrumentation-graphql": "^0.36.0",
-        "@opentelemetry/instrumentation-grpc": "^0.45.1",
-        "@opentelemetry/instrumentation-hapi": "^0.33.2",
-        "@opentelemetry/instrumentation-http": "^0.45.1",
-        "@opentelemetry/instrumentation-ioredis": "^0.36.0",
-        "@opentelemetry/instrumentation-knex": "^0.32.3",
-        "@opentelemetry/instrumentation-koa": "^0.36.3",
-        "@opentelemetry/instrumentation-lru-memoizer": "^0.33.4",
-        "@opentelemetry/instrumentation-memcached": "^0.32.4",
-        "@opentelemetry/instrumentation-mongodb": "^0.38.0",
-        "@opentelemetry/instrumentation-mongoose": "^0.33.4",
-        "@opentelemetry/instrumentation-mysql": "^0.34.4",
-        "@opentelemetry/instrumentation-mysql2": "^0.34.4",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.33.3",
-        "@opentelemetry/instrumentation-net": "^0.32.4",
-        "@opentelemetry/instrumentation-pg": "^0.37.1",
-        "@opentelemetry/instrumentation-pino": "^0.34.4",
-        "@opentelemetry/instrumentation-redis": "^0.35.4",
-        "@opentelemetry/instrumentation-redis-4": "^0.35.5",
-        "@opentelemetry/instrumentation-restify": "^0.34.2",
-        "@opentelemetry/instrumentation-router": "^0.33.3",
-        "@opentelemetry/instrumentation-socket.io": "^0.34.4",
-        "@opentelemetry/instrumentation-tedious": "^0.6.4",
-        "@opentelemetry/instrumentation-winston": "^0.33.0",
-        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.4",
-        "@opentelemetry/resource-detector-aws": "^1.3.4",
-        "@opentelemetry/resource-detector-container": "^0.3.4",
-        "@opentelemetry/resource-detector-gcp": "^0.29.4",
+        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.33.5",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.37.4",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.37.2",
+        "@opentelemetry/instrumentation-bunyan": "^0.34.1",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.34.2",
+        "@opentelemetry/instrumentation-connect": "^0.32.4",
+        "@opentelemetry/instrumentation-cucumber": "^0.2.1",
+        "@opentelemetry/instrumentation-dataloader": "^0.5.4",
+        "@opentelemetry/instrumentation-dns": "^0.32.5",
+        "@opentelemetry/instrumentation-express": "^0.34.1",
+        "@opentelemetry/instrumentation-fastify": "^0.32.6",
+        "@opentelemetry/instrumentation-fs": "^0.8.4",
+        "@opentelemetry/instrumentation-generic-pool": "^0.32.5",
+        "@opentelemetry/instrumentation-graphql": "^0.36.1",
+        "@opentelemetry/instrumentation-grpc": "^0.46.0",
+        "@opentelemetry/instrumentation-hapi": "^0.33.3",
+        "@opentelemetry/instrumentation-http": "^0.46.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.36.1",
+        "@opentelemetry/instrumentation-knex": "^0.32.4",
+        "@opentelemetry/instrumentation-koa": "^0.36.4",
+        "@opentelemetry/instrumentation-lru-memoizer": "^0.33.5",
+        "@opentelemetry/instrumentation-memcached": "^0.32.5",
+        "@opentelemetry/instrumentation-mongodb": "^0.38.1",
+        "@opentelemetry/instrumentation-mongoose": "^0.34.0",
+        "@opentelemetry/instrumentation-mysql": "^0.34.5",
+        "@opentelemetry/instrumentation-mysql2": "^0.34.5",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.33.4",
+        "@opentelemetry/instrumentation-net": "^0.32.5",
+        "@opentelemetry/instrumentation-pg": "^0.37.2",
+        "@opentelemetry/instrumentation-pino": "^0.34.5",
+        "@opentelemetry/instrumentation-redis": "^0.35.5",
+        "@opentelemetry/instrumentation-redis-4": "^0.35.6",
+        "@opentelemetry/instrumentation-restify": "^0.34.3",
+        "@opentelemetry/instrumentation-router": "^0.33.4",
+        "@opentelemetry/instrumentation-socket.io": "^0.35.0",
+        "@opentelemetry/instrumentation-tedious": "^0.6.5",
+        "@opentelemetry/instrumentation-winston": "^0.33.1",
+        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.5",
+        "@opentelemetry/resource-detector-aws": "^1.3.5",
+        "@opentelemetry/resource-detector-container": "^0.3.5",
+        "@opentelemetry/resource-detector-gcp": "^0.29.5",
         "@opentelemetry/resources": "^1.12.0",
-        "@opentelemetry/sdk-node": "^0.45.1"
+        "@opentelemetry/sdk-node": "^0.46.0"
       },
       "engines": {
         "node": ">=14"
@@ -494,352 +494,11 @@
         "@opentelemetry/api": "^1.4.1"
       }
     },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.18.1.tgz",
-      "integrity": "sha512-HHfJR32NH2x0b69CACCwH8m1dpNALoCTtpgmIWMNkeMGNUeKT48d4AX4xsF4uIRuUoRTbTgtSBRvS+cF97qwCQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/core": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
-      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.45.1.tgz",
-      "integrity": "sha512-c/Wrn6LUqPiRgKhvMydau6kPz4ih6b/uwospiavjXju98ZfVv+KjaIF13cblW+4cQ6ZR3lm7t66umQfXrGBhPQ==",
-      "dev": true,
-      "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.45.1",
-        "@opentelemetry/otlp-transformer": "0.45.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/sdk-trace-base": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.45.1.tgz",
-      "integrity": "sha512-a6CGqSG66n5R1mghzLMzyzn3iGap1b0v+0PjKFjfYuwLtpHQBxh2PHxItu+m2mXSwnM4R0GJlk9oUW5sQkCE0w==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/otlp-exporter-base": "0.45.1",
-        "@opentelemetry/otlp-transformer": "0.45.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/sdk-trace-base": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.45.1.tgz",
-      "integrity": "sha512-8QI6QARxNP4y9RUpuQxXjw2HyRNyeuD9CWEhS5ON44Mt+XP7YbOZR3GLx2Ml2JZ8uzB5dd2EGlMgaMuZe36D5Q==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/otlp-exporter-base": "0.45.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.45.1",
-        "@opentelemetry/otlp-transformer": "0.45.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/sdk-trace-base": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.18.1.tgz",
-      "integrity": "sha512-RmoWVFXFhvIh3q4szUe8I+/vxuMR0HNsOm39zNxnWJcK7JDwnPra9cLY/M78u6bTgB6Fte8GKgU128vvDzz0Iw==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/sdk-trace-base": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.45.1.tgz",
-      "integrity": "sha512-Jvd6x8EwWGKEPWF4tkP4LpTPXiIkkafMNMvMJUfJd5DyNAftL1vAz+48jmi3URL2LMPkGryrvWPz8Tdu917gQw==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.45.1.tgz",
-      "integrity": "sha512-81X4mlzaAFoQCSXCgvYoMFyTy3mBhf8DD3J8bjW6/PH/rGZPJJkyYW0/YzepMrmBZXqlKZpTOU1aJ8sebVvDvw==",
-      "dev": true,
-      "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/otlp-exporter-base": "0.45.1",
-        "protobufjs": "^7.2.3"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.45.1.tgz",
-      "integrity": "sha512-jtDkly6EW8TZHpbPpwJV9YT5PgbtL5B2UU8zcyGDiLT1wkIAYjFJZ1AqWmROIpydu8ohMq0dRwe4u0izNMdHpA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/otlp-exporter-base": "0.45.1",
-        "protobufjs": "^7.2.3"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.45.1.tgz",
-      "integrity": "sha512-FhIHgfC0b0XtoBrS5ISfva939yWffNl47ypXR8I7Ru+dunlySpmf2TLocKHYLHGcWiuoeSNO5O4dZCmSKOtpXw==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.45.1",
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/sdk-logs": "0.45.1",
-        "@opentelemetry/sdk-metrics": "1.18.1",
-        "@opentelemetry/sdk-trace-base": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.18.1.tgz",
-      "integrity": "sha512-oSTUOsnt31JDx5SoEy27B5jE1/tiPvvE46w7CDKj0R5oZhCCfYH2bbSGa7NOOyDXDNqQDkgqU1DIV/xOd3f8pw==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.18.1.tgz",
-      "integrity": "sha512-Kh4M1Qewv0Tbmts6D8LgNzx99IjdE18LCmY/utMkgVyU7Bg31Yuj+X6ZyoIRKPcD2EV4rVkuRI16WVMRuGbhWA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/resources": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
-      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.45.1.tgz",
-      "integrity": "sha512-z0RRgW4LeKEKnhXS4F/HnqB6+7gsy63YK47F4XAJYHs4s1KKg8XnQ2RkbuL31i/a9nXkylttYtvsT50CGr487g==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/resources": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.8.0",
-        "@opentelemetry/api-logs": ">=0.39.1"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.18.1.tgz",
-      "integrity": "sha512-TEFgeNFhdULBYiCoHbz31Y4PDsfjjxRp8Wmdp6ybLQZPqMNEb+dRq+XN8Xw3ivIgTaf9gYsomgV5ensX99RuEQ==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/resources": "1.18.1",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/sdk-node": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.45.1.tgz",
-      "integrity": "sha512-VtYvlz2ydfJLuOUhCnGER69mz2KUYk3/kpbqI1FWlUP+kzTwivMuy7hIPPv6KmuOIMYWmW4lM+WyJACHqNvROw==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.45.1",
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.45.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.45.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.45.1",
-        "@opentelemetry/exporter-zipkin": "1.18.1",
-        "@opentelemetry/instrumentation": "0.45.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/sdk-logs": "0.45.1",
-        "@opentelemetry/sdk-metrics": "1.18.1",
-        "@opentelemetry/sdk-trace-base": "1.18.1",
-        "@opentelemetry/sdk-trace-node": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
-      "integrity": "sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.18.1.tgz",
-      "integrity": "sha512-ML0l9TNlfLoplLF1F8lb95NGKgdm6OezDS3Ymqav9sYxMd5bnH2LZVzd4xEF+ov5vpZJOGdWxJMs2nC9no7+xA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.18.1",
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/propagator-b3": "1.18.1",
-        "@opentelemetry/propagator-jaeger": "1.18.1",
-        "@opentelemetry/sdk-trace-base": "1.18.1",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.19.0.tgz",
       "integrity": "sha512-0i1ECOc9daKK3rjUgDDXf0GDD5XfCou5lXnt2DALIc2qKoruPPcesobNKE54laSVUWnC3jX26RzuOa31g0V32A==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -851,6 +510,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.19.0.tgz",
       "integrity": "sha512-w42AukJh3TP8R0IZZOVJVM/kMWu8g+lm4LzT70WtuKqhwq7KVhcDzZZuZinWZa6TtQCl7Smt2wolEYzpHabOgw==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.19.0"
       },
@@ -865,6 +525,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.46.0.tgz",
       "integrity": "sha512-kR4kehnfIhv7v/2MuNYfrlh9A/ZtQofwCzurTIplornUjdzhKDGgjui1NkNTqTfM1QkqfCiavGsf5hwocx29bA==",
+      "dev": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.19.0",
@@ -884,6 +545,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.46.0.tgz",
       "integrity": "sha512-vZ2pYOB+qrQ+jnKPY6Gnd58y1k/Ti//Ny6/XsSX7/jED0X77crtSVgC6N5UA0JiGJOh6QB2KE9gaH99010XHzg==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/otlp-exporter-base": "0.46.0",
@@ -902,6 +564,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.46.0.tgz",
       "integrity": "sha512-A7PftDM57w1TLiirrhi8ceAnCpYkpUBObELdn239IyYF67zwngImGfBLf5Yo3TTAOA2Oj1TL76L8zWVL8W+Suw==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/otlp-exporter-base": "0.46.0",
@@ -921,6 +584,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.19.0.tgz",
       "integrity": "sha512-TY1fy4JiOBN5a8T9fknqTMcz0DXIeFBr6sklaLCgwtj+G699a5R4CekNwpeM7DHSwC44UMX7gljO2I6dYsTS3A==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/resources": "1.19.0",
@@ -935,13 +599,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.45.1.tgz",
-      "integrity": "sha512-V1Cr0g8hSg35lpW3G/GYVZurrhHrQZJdmP68WyJ83f1FDn3iru+/Vnlto9kiOSm7PHhW+pZGdb9Fbv+mkQ31CA==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.46.0.tgz",
+      "integrity": "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw==",
       "dev": true,
       "dependencies": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.4.2",
+        "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -954,13 +618,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.33.4.tgz",
-      "integrity": "sha512-fL+WrEsIM3cP4VTOsqR8enlT/4VX+OCVF7WALN85bgdFPSRpv2X7ZqsXOdYd358cAp4KO9MiveSkAKwKcTXKLw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.33.5.tgz",
+      "integrity": "sha512-WQ/XPzNLOHL3fpsmgoQUkiKCkJ09hvPN8wGrGzzOHMiJ5/3LqvfvxsJ4Rcd6aWkA4il3hEfpl+V0VF0t/DP65A==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -971,12 +635,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.37.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.37.3.tgz",
-      "integrity": "sha512-TlFeG0xZSMIg0CZwonpmrCrPHPfwSWbsg/P+NwY64i+jq0ysYfj/2trkHVDOUtC636FR1NaPLAuZBMVAMPhILA==",
+      "version": "0.37.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.37.4.tgz",
+      "integrity": "sha512-/wdZwUalIWAbxeycvmE+25c1xCMhe5EUuj8bN0MWWN3L8N2SYvfv6DmiRgwrTIPXRgIyFugh2udNiF4MezZN4Q==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -990,14 +654,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.37.1.tgz",
-      "integrity": "sha512-vIvA9LpxLMHx0sraBF+qyiGuiqeeLz2CKQPoV4bAlzd+Zlcwk3Yg/NHHjMvP7aCy1VB6cGS8UkMG5lNM1a1NmQ==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.37.2.tgz",
+      "integrity": "sha512-eFHHOk0P9EFQ9Ho+2w7KH9R8cH7hut0/ePSsrk0nAM6Tiq2lBPeHn8ialCWESAA9jSjy+iuDelwmqAEXEe+jrg==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
-        "@opentelemetry/propagation-utils": "^0.30.4",
+        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/propagation-utils": "^0.30.5",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1008,13 +672,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.34.0.tgz",
-      "integrity": "sha512-UjuvggGrclyn6avTcMAdqLyrrTV26ufB73vPBPlEmA3a2dtYCS07zW82Kacxi5emZDpmHIk6zQE18DqCb/xfpA==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.34.1.tgz",
+      "integrity": "sha512-+eshbCFr2dkUYO2jCpbYGFC5hs94UCOsQRK1XqNOjeiNvQRtqvKYqk8ARwJBYBX+aW4J02jOliAHQUh/d7gYPg==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.45.1",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/api-logs": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@types/bunyan": "1.8.9"
       },
       "engines": {
@@ -1024,13 +688,25 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.34.1.tgz",
-      "integrity": "sha512-n2bjMeKctNpXYW/vHURMCOXm56HFgQiD4fyIWioUvLROaPunKDvQpJlCLS88QMQ3f3pz/fp8Bde6gXuciLePxQ==",
+    "node_modules/@opentelemetry/instrumentation-bunyan/node_modules/@opentelemetry/api-logs": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.46.0.tgz",
+      "integrity": "sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.34.2.tgz",
+      "integrity": "sha512-wuzq7QQ9o7PJnzseblNfBcURtM+9AwO6e1m644QYtAb/6YRR6qg6gAmAipVeQu01H5BuHBFC/92svaAkdIV2WQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1041,13 +717,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.32.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.32.3.tgz",
-      "integrity": "sha512-5BK52mIjNuKgY/RV8h0GLmS4qunXqkCIL7NZ73dJ40pnKMA8jqF5D5A2tFjWkCCQ4BdYfAfyjjiA+uTGoL3ZGg==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.32.4.tgz",
+      "integrity": "sha512-oUGph9idncdnHlQMwdIs6m6mii7Kdp9PpHkM9roOZy71h+2vvf6+cVn45bs2unBbE2Vxho2i/049QQbaYKDYlw==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.36"
       },
@@ -1059,12 +735,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cucumber": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.2.0.tgz",
-      "integrity": "sha512-2YWTeSrBrpTCvLoSka/ZkEl0I2YkwKrxi13d3xQqbEySJyyLnxrYoFkPhTn7uqhKOEwnh1B8MXunNXhMyei29Q==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.2.1.tgz",
+      "integrity": "sha512-ydF0DpmE0D6wccAbxx1F+6kokzcSSRy3X78Bvgok/3fHUSSshGLErqNiQL1HV44OIcV6392P3tu/jtXtUq3UDQ==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1075,12 +751,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.5.3.tgz",
-      "integrity": "sha512-tHpLbcjtdiDFLHFfYjmyKjnDYCQLmp6ceflsA9H4BEEwSE2p5ZW512TQl3abzb3EQK2V7+I1gqIuMGHKxmKIlg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.5.4.tgz",
+      "integrity": "sha512-l1qQvvygxZJw+S+4hgYgzvT4GArqBrar42wzB5LVsOy04+gmbDw/4y7IqxZYepFyXKuBownGS8pR4huRL/Tj/A==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       },
       "engines": {
         "node": ">=14"
@@ -1090,12 +766,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.32.4.tgz",
-      "integrity": "sha512-04DTRKFDEpKgYpCqPGlnpCS0atuRUmAPj35xNGV/H7bZTCA3ZR77NeR3f4tYVfqlnsi3KiM1HzgrhwNBskVIEw==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.32.5.tgz",
+      "integrity": "sha512-fHJqrbezpZSipo4O9nF9yGq6R8oyr1W2gSlyk1foJNXBaqdCODTlzIa7BP50vGtLBN/m+qO8pMOWCJmYSBX35g==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.5.4"
       },
@@ -1122,13 +798,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.34.0.tgz",
-      "integrity": "sha512-wgMKa9vaCWAsgu/dNZwbRM1/6RusKZ7yWdlPhTzeI9RNE13we+KYIQKA1YFGuTypRMRTixwrJLHdy927y0TjAA==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.34.1.tgz",
+      "integrity": "sha512-pQBQxXpkH6imvzwCdPcw2FKjB1cphoRpmWTiGi6vtBdKXCP0hpne613ycpwhGG7C17S+mbarVmukbJKR4rmh6Q==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1139,13 +815,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.32.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.5.tgz",
-      "integrity": "sha512-u88jctr2Y04N8ALpO448s6IH5F0RB3XXa8+fJ+SMh0JsDwpX4oJZGjbnXSKZP0Gl9FscWIENasNoedW+R2vaHw==",
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.6.tgz",
+      "integrity": "sha512-UkBu8rAqeVC034jsRMiEAmYhFQ03pvmE/MnoPKE9gAbgVtPILdekHYqAKM0MdqnEjW7pO45t4wWsbtIcN0eiBw==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1156,13 +832,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.8.3.tgz",
-      "integrity": "sha512-o5uy91VAvXl1i71/AH3C6KV/6KQVGsnuNmjfUAJo4QqY2ta0Uzlpa0wy0nXvQUAP/3QbTx7NcF3rk3mVxLmgeg==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.8.4.tgz",
+      "integrity": "sha512-g99963nK8TuisUM3KH+ee5hOCHdCHSKiAdmy0RMdiKT7ITh3rXUct7fghQibViQA7FVPkdwM9+uRKkigJSFS9w==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1173,12 +849,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.32.4.tgz",
-      "integrity": "sha512-NDNzoZ0MCmHeMQRxm1eL0l8fCoHIYFiugu5AZ4wt+S2wbgyh5BCd+ZAqTzSFEJGKGg7KZMfHgVRTiCsj+ljfvA==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.32.5.tgz",
+      "integrity": "sha512-MNFloXa3SDg/rHh397JnWADr7iYQ6HHRwT7ZId5Vt0L1Xx+Qp3XSIILsXk5qTXVUIytEIVgn8iMT+kZILHzSqg==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1189,12 +865,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.36.0.tgz",
-      "integrity": "sha512-H5nezZCV4HUjmPi4o2QlFXGzvldZiJ7hAEldy+37qMmm5PaqLmFW4w084/C+4IdPoxm4gJRtI8vkXJQJqqyktQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.36.1.tgz",
+      "integrity": "sha512-EOvaS+d2909TOJJjNTsb0vHaLg8WdTLoQS8bRKdy3lMgdd7I4OL9/LSC7dp4M8CvJKz9B464Ix9PnARvhMkNOw==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       },
       "engines": {
         "node": ">=14"
@@ -1204,13 +880,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.45.1.tgz",
-      "integrity": "sha512-KyssKMi+cMAWc+9buGs7nHjnHm4wQPH99etunFblZCKQlzgPB+s8Q6aIlJ3LCkCaOGAhofpr4IkWh7dMcapJJQ==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.46.0.tgz",
+      "integrity": "sha512-KemIpB4jmywQv/+MbVoUIMVp3vr+rzra37TYbN7kTsbrn213YlzdXVamf6nq/yChI6q+9JlUnCdSZf86D6NO6g==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.45.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/instrumentation": "0.46.0",
+        "@opentelemetry/semantic-conventions": "1.19.0"
       },
       "engines": {
         "node": ">=14"
@@ -1219,23 +895,14 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.33.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.33.2.tgz",
-      "integrity": "sha512-XSe1/emVguKMEiV+ctva+Z9GI/3scPBwtNFAVcJFpM4ekK0SiIF73uBKmaC0mVnU+TIToPlkOC7nbkEbXq6y1g==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.33.3.tgz",
+      "integrity": "sha512-l14u1TFPXMUjfHqnrHtzuMyLq6V8BikwhYJO/hIgkbaPCxS38TloCtDLJvcs8S8AZlcQfkUqE/NFgXYETZRo+Q==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.13"
       },
@@ -1247,14 +914,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.45.1.tgz",
-      "integrity": "sha512-ph7kv38Lipg/ggvoNJrwc3RCceLnTkVZwRbE5iu6w7fGsMjjc9jwlSmaOXKxUJjIimil2hL1qBm8xg2lmOVwxg==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.46.0.tgz",
+      "integrity": "sha512-t5cxgqfV9AcxVP00/OL1ggkOSZM57VXDpvlWaOidYyyfLKcUJ9e2fGbNwoVsGFboRDeH0iFo7gLA3EEvX13wCA==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/instrumentation": "0.45.1",
-        "@opentelemetry/semantic-conventions": "1.18.1",
+        "@opentelemetry/core": "1.19.0",
+        "@opentelemetry/instrumentation": "0.46.0",
+        "@opentelemetry/semantic-conventions": "1.19.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -1262,30 +929,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
-      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.18.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-http/node_modules/semver": {
@@ -1304,12 +947,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.36.0.tgz",
-      "integrity": "sha512-LmEHE3w8JzPpm2TEPiwjAjOSIPWM6t39TFNXu796IJba35k0ZZG9qQRaxv8CS61EZIT1eH7qgExHwEmPHsOl8Q==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.36.1.tgz",
+      "integrity": "sha512-xxab7n4TD5igCFR5N0j5PJFYVeOXm54ZtCARVS32xavwGyGf+Sb6VtuVCLdl0re4JENCg18FO97Dyb1ql2EBUA==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
@@ -1322,12 +965,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.32.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.32.3.tgz",
-      "integrity": "sha512-8+JvZ1Gs9pMe6pgQfMVjth52WCUuKUu0L0tx237VAA53HHUtsCNPznBHp2EAlsLGSLLptfPvzXz/Bdp009ja8w==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.32.4.tgz",
+      "integrity": "sha512-vqxK1wqhktQnBA7nGr6nqfhV5irSXK9v0R29hqlyTr/cB/86Hn3Z98zH58QvHo131FcE+d70QdiXu3P9S5vq4g==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1338,13 +981,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.36.3.tgz",
-      "integrity": "sha512-ffn76qSuGUUtEBc8IZ1RHc//Y10ZKHku4QjPlpZY5/BtEd2xMV4iXmMdeJngKFiHrVKCvreyC5ON5hHcaQp32g==",
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.36.4.tgz",
+      "integrity": "sha512-Qt6IF0mo3FZZ+x4NQhv/pViDtPSw/h/QYDvyIqMCuqUibqta619WLUCwAcanKnZWvzMuYh6lT0TnZ8ktjXo6jQ==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.9",
         "@types/koa__router": "12.0.3"
@@ -1357,12 +1000,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.33.4.tgz",
-      "integrity": "sha512-SOO9y15z27n5VpjjHiT1r1H+uNxBHRaHX1z6DhGG0BjaJkyu9p6CSjXhsXu2gsAoubRKMSAd0Q+axf1MiVqhvw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.33.5.tgz",
+      "integrity": "sha512-vbm9QPEYD3FZNGSa+7xQ7uOkgbJtskIwp1KnsCpmdBBiulhBaqqgeNLFo7gd8UxMrI2Vu3LTlZil2D0dVt8g/A==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       },
       "engines": {
         "node": ">=14"
@@ -1372,12 +1015,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.32.4.tgz",
-      "integrity": "sha512-q9uswokVrtgKFiVNb3QoTFFulXiHpm6FDOvI/3uO8/TnhhpUh776EuD5kDI0YWZ3J+gkN2Dj82KrmOfqBS5o1A==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.32.5.tgz",
+      "integrity": "sha512-1MS9LfgZruAsWOHVDTI+/Wy9mFFivUlpGUwYC4D+ho1I4NUyE33XHwL1BKcjMupkuRnE0JmbhdBfTG9Ai1vFkw==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       },
@@ -1389,12 +1032,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.38.0.tgz",
-      "integrity": "sha512-nIepSpS3zQsJuDRRjZXMPvnUT7u3xn/+tWKnGB5jIQOstK5O1Nd6pkiPzi1VUmLDBJ1o31N+388mAxSpEqve0g==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.38.1.tgz",
+      "integrity": "sha512-X6YjE8dOCf8lG8FGmoAvczZq7LtgYaRzZcLGthZSUJQ2rfp1JJRlJixc+COvhrn1HJj5ab+AsSdUQgTpfQgEHQ==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -1406,29 +1049,29 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.33.4.tgz",
-      "integrity": "sha512-qPwurJjzxJVIzvlRmN4KADQ+BeD2KsDcEH7fMRPMZ35R90+0fQO3RFmINaO5zUpmYY1tHsw3zhnQVD23Dq+pfA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.34.0.tgz",
+      "integrity": "sha512-/wGNK7qR/QXpcidXntKsnfACHETp8G/f2o/k8FPvJ2lukvdM9r7cHLys8QwkJkTN8Kt3qG1VIwarGKYtE/zOSw==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.34.4.tgz",
-      "integrity": "sha512-LWpCGoKuSoHYIzI/SN3unkNkthdFHGyA3vJJWPmtLPxEP9qtCc2gAJUQQ6Q+73YJmHZdXlZSe7sOqGdKx/KyjQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.34.5.tgz",
+      "integrity": "sha512-cE8z1uJTeLcMj+R31t1pLkLqt3ryGMl1HApxsqqf8YCSHetrkVwGZOcyQ3phfgGSaNlC4/pdf3CQqfjhXbLWlA==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.22"
       },
@@ -1440,12 +1083,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.34.4.tgz",
-      "integrity": "sha512-pgf7UUMiQFUbfzj2WkjOdzT8IoffsqlAbIdMobyAc2Ca90fIYrpEeIpurkzDJWsw1x4GaQRXmJuERhccgr5BSg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.34.5.tgz",
+      "integrity": "sha512-Ai3+cJ83b11kLypIVEPLHuYCiIQjf828hHJPpllr78EhmHiq4S1yTW34aP3BzCBY+5Adr5PS5Nnv7NLBI/YfaQ==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0"
       },
@@ -1457,12 +1100,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.33.3.tgz",
-      "integrity": "sha512-B5v8Qi0chpHHgp/BeL5EcxQnnjm6OTYiMlGk6rM5X/xz9AdB60fAIXWerKKrG1QQ8JVcS5O4nhP4NzPC0JLjWw==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.33.4.tgz",
+      "integrity": "sha512-AynD6TesE0bZg9UzS4ZLG//6TmU8GkRrjubhxs7jYZ3JRAlJAq1In0zSwM082JOIs7wr286nhs1FmqK91cG1cg==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1473,12 +1116,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.32.4.tgz",
-      "integrity": "sha512-sZUELN+pO73Mo2zXOt9pTrmwsVtf/WvOOjh+ItFYth4X5syOcHA192NvoEPLqIgWv0L5Iipm8M2SiWZiWm2X7w==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.32.5.tgz",
+      "integrity": "sha512-omBLTXyJeCtBy1MzVi+IzUcpXiup90k0z3AGhNKbzro4RhpsdMpN9O+3zZCXCIHMuyifhy7z8w99wmvvFO/FCQ==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1489,13 +1132,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.37.1.tgz",
-      "integrity": "sha512-yJcTdwsnFqHLFR+uaS2mIvXfHnlzSD2VWgSvka9Y3SSZepcpiEbVs9G897p0XVNpNImo4+CfhOD6Mh5kL6o7Vg==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.37.2.tgz",
+      "integrity": "sha512-MAiKqdtGItYjvD6rOCyGS27CdMaDnh2JuImIHXhrPjq/sb2JlBNm6m1e4BH4uik1VfcKt/I3pI3UkydSWIscCg==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0",
         "@types/pg": "8.6.1",
@@ -1509,12 +1152,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.34.4.tgz",
-      "integrity": "sha512-cD4PssCNjOqc0h1vFLqIDYR8ajqwuOZfp3rk5dTyeiroUmfs6wzd4wc/Sfe/pVPsGkx+nRiFdfbpW1+DtZGHAg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.34.5.tgz",
+      "integrity": "sha512-auYDSeFhkPFXayT/060mQRL7O88Bt5NKcV0qOfquNa9J5/qs5dlJYdTOraxPrjiGPM3tHaAJ+AvAhR0CPYgZew==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       },
       "engines": {
         "node": ">=14"
@@ -1524,12 +1167,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.35.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.4.tgz",
-      "integrity": "sha512-MNO/cuHQMeafNu+K8PdrZDGPjWLsQTmyfJzzjasQgm6ELe+/6deNZzsAXkRK4e4sx+FJH7NDnyyqti/dhB4IeQ==",
+      "version": "0.35.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.5.tgz",
+      "integrity": "sha512-UPYUncDlLqDPtyU11UhyZOUxAyPQS6yQGT0b96KjpqMhmuRb3b0WxzZh3SoIaAyprL5f9fxyeV2HfSulR0aWFQ==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -1541,12 +1184,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.35.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.35.5.tgz",
-      "integrity": "sha512-+CuWyS1QOc/RYGSyLr/3VkXiNVU4rstsJi+b5j1sh4Mzy4sIrOtRQRcl74PXh06vOnSyGTToyQ9n4BKZuHODbQ==",
+      "version": "0.35.6",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.35.6.tgz",
+      "integrity": "sha512-OVSUJZAuy6OX18X2TKPdPlpwM5t4FooJU9QXiUxezhdMvfIAu00Agchw+gRbszkM7nvQ9dkXFOZO3nTmJNcLcA==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -1558,13 +1201,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.34.2.tgz",
-      "integrity": "sha512-W9fZJ6hH7PNIhzcKcmFjUgU87vnM1gPa/YTW724lZ9ItHPUol4wAcnv/F88xM+eouuZKLmCaCahZYp0tx7D/Ig==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.34.3.tgz",
+      "integrity": "sha512-nUqf4RTcQyc/YTWMT0e/ZqvuQqhRH04MOoSwaH6ocmyrEhKdPDq9AbvSMerQ/AxNC9yju/PytgzFFWH45hh3KA==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1575,12 +1218,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-router": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.33.3.tgz",
-      "integrity": "sha512-LbD+9YBx4SKK10WQ06s2iy9/tN9lQmlgneqem46WKi8rX0W2vo1VX5TEM+Bvn7d5lM5uaPDFGosQR++g52BSDQ==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.33.4.tgz",
+      "integrity": "sha512-4140BgILsL0H8tA0BBN2tjzajgjxlDqd4xPatk2i5q9ofy8wlB0BlDJ4m36U7G1z0v+a+LshQSNqPP2VHZ9ORw==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -1591,28 +1234,28 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-socket.io": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.34.4.tgz",
-      "integrity": "sha512-r56esRFNEULo8p4iJ0xsd3JkzUPPtLrIeiX0YnqI5hzaoOz3bmUO7qu6/iiEX9/Ej9/rL0U5ZaEIEmagJIUcIw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.35.0.tgz",
+      "integrity": "sha512-ED1/Wco05H9fepKqX7n2kONq9EXxkBZTKS29nUH9vVL7wSIT8sBIDqpHz94CnQ8xuicaQQ7c5h9TVuhjtzV43Q==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.6.4.tgz",
-      "integrity": "sha512-bjoagT4AO26QXpv7bE4Vyrwcqxq0ntA2pWCLDHuXRnlt+iWyQm4dS/ExjQR4OuO8aRgeuk/3YC7dSl1rtdO7Kg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.6.5.tgz",
+      "integrity": "sha512-jjdrDegLUodz9np0yKCAa7sLxlAGTsxM7wU7l1mQ2NM6PHAGv4X3eSFClUk3fOipLx4+r5jTLnlsgu7g9CW+Qw==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/tedious": "^4.0.10"
       },
@@ -1624,12 +1267,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.33.0.tgz",
-      "integrity": "sha512-kf4GC6/IVDt+XumUZ54kB3G+1Kc3TfaLY63uZ+9Qi25LBPeBSYJHQugSvxZ9mK/5Uyf9rPxW2FevjblNyaY54w==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.33.1.tgz",
+      "integrity": "sha512-4tSORoAY9f+yzqNVGcGr/3GydPMfgSiKK1OESc+qBwVTz0bmz4cOrhCruCngGzoqDCmPYpwqwR/8j4wRKgcUpw==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       },
       "engines": {
         "node": ">=14"
@@ -1657,6 +1300,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.46.0.tgz",
       "integrity": "sha512-hfkh7cG17l77ZSLRAogz19SIJzr0KeC7xv5PDyTFbHFpwwoxV/bEViO49CqUFH6ckXB63NrltASP9R7po+ahTQ==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0"
       },
@@ -1671,6 +1315,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.46.0.tgz",
       "integrity": "sha512-/KB/xfZZiWIY2JknvCoT/e9paIzQO3QCBN5gR6RyxpXM/AGx3YTAOKvB/Ts9Va19jo5aE74gB7emhFaCNy4Rmw==",
+      "dev": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.19.0",
@@ -1688,6 +1333,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.46.0.tgz",
       "integrity": "sha512-rEJBA8U2AxfEzrdIUcyyjOweyVFkO6V1XAxwP161JkxpvNuVDdULHAfRVnGtoZhiVA1XsJKcpIIq2MEKAqq4cg==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/otlp-exporter-base": "0.46.0",
@@ -1704,6 +1350,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.46.0.tgz",
       "integrity": "sha512-Fj9hZwr6xuqgsaERn667Uf6kuDG884puWhyrai2Jen2Fq+bGf4/5BzEJp/8xvty0VSU4EfXOto/ys3KpSz2UHg==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.46.0",
         "@opentelemetry/core": "1.19.0",
@@ -1723,6 +1370,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.46.0.tgz",
       "integrity": "sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -1731,9 +1379,9 @@
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.4.tgz",
-      "integrity": "sha512-drYvwfhdXZ6ax5xnpuEQ/0C0AaCcxXcf47wZFNIK4DZu2RJmGk24XUSGWg5XI9gMKBe5qwXWBh9aSlSLWdA/Ww==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.5.tgz",
+      "integrity": "sha512-9ENyx6ptmjyYzL7le3FXk/lJc3cFFTrh9Y/ubO9velQZ64BdjpF9kOMJN3Z8KLJFVt66HYoWy9xlWoSIfS/ICg==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -1761,6 +1409,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.19.0.tgz",
       "integrity": "sha512-v7y5IBOKBm0vP3yf0DHzlw4L2gL6tZ0KeeMTaxfO5IuomMffDbrGWcvYFp0Dt4LdZctTSK523rVLBB9FBHBciQ==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0"
       },
@@ -1775,6 +1424,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.19.0.tgz",
       "integrity": "sha512-dedkOoTzKg+nYoLWCMp0Im+wo+XkTRW6aXhi8VQRtMW/9SNJGOllCJSu8llToLxMDF0+6zu7OCrKkevAof2tew==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0"
       },
@@ -1795,9 +1445,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-      "version": "0.28.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.4.tgz",
-      "integrity": "sha512-acesz8NgW6asYZNWJvLT/PwaM18iFaVgiEkhPEVtAberyl9+l+e8FBSvCFgV6KSAPnBMbdv11dkN1dSAAqqREg==",
+      "version": "0.28.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.5.tgz",
+      "integrity": "sha512-cobe2I0c5a66d98nCBprEB5erN5S0PTRrs49qSOnuTT2dC90nwSo2WDcSBfeDSKZH/7sB686P7FyKefWjQzhoA==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
@@ -1811,9 +1461,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.4.tgz",
-      "integrity": "sha512-G6QK5kcLbqxF4zNFfuXyqZtWecNzwKVVqo/gEXlF3EZSIImPH2bGkElL8HpW9OGktWCqbbjYRTSo8VEjs6PxWA==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.5.tgz",
+      "integrity": "sha512-0GZJi8m6czksDJwpndSYJpnaPaFe83nEQVg4UnTTwB0cxKtrjpaarWDI46X0BuCX4bGp0M8pvI7f0rBt+LsIhA==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
@@ -1828,9 +1478,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-container": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.4.tgz",
-      "integrity": "sha512-p04SnseEk5P18T+90LscSdMYmehrn+paoLgE3s0BEusA+FDail1jRD0SsnoTHO94SM0XePIeaG6ip2n4Id9+8Q==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.5.tgz",
+      "integrity": "sha512-yLGLueH63DE9/WmDrizleqtT0uCOsslNqW+AcwzMHW7t8c2MtoJ7msgIsmi7tz5kxJgG8o54CnvXxobcwBhLCQ==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
@@ -1844,9 +1494,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-gcp": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.4.tgz",
-      "integrity": "sha512-YoUYYwjcCRRxkHHFco29Hli+dVrIPMDTkJqQ0BaH4MDkfFg4HEbO/WarNHxSv5wAIl3SiI4sYyNJ6qfK5Z92zQ==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.5.tgz",
+      "integrity": "sha512-cYckfRDDNX/nhiMF7fFooOCb/EObydNXWi0HwuPELHYa7heBCkWgTtNxs/PzuP46+FqDjuBcJL6beS2Ef7MyWg==",
       "dev": true,
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
@@ -1865,6 +1515,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.19.0.tgz",
       "integrity": "sha512-RgxvKuuMOf7nctOeOvpDjt2BpZvZGr9Y0vf7eGtY5XYZPkh2p7e2qub1S2IArdBMf9kEbz0SfycqCviOu9isqg==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/semantic-conventions": "1.19.0"
@@ -1880,6 +1531,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.46.0.tgz",
       "integrity": "sha512-Knlyk4+G72uEzNh6GRN1Fhmrj+/rkATI5/lOrevN7zRDLgp4kfyZBGGoWk7w+qQjlYvwhIIdPVxlIcipivdZIg==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/resources": "1.19.0"
@@ -1896,6 +1548,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.19.0.tgz",
       "integrity": "sha512-FiMii40zr0Fmys4F1i8gmuCvbinBnBsDeGBr4FQemOf0iPCLytYQm5AZJ/nn4xSc71IgKBQwTFQRAGJI7JvZ4Q==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/resources": "1.19.0",
@@ -1912,6 +1565,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.46.0.tgz",
       "integrity": "sha512-BQhzdCRZXchhKjZaFkgxlgoowjOt/QXekJ1CZgfvFO9Yg5GV15LyJFUEyQkDyD8XbshGo3Cnj0WZMBnDWtWY1A==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.46.0",
         "@opentelemetry/core": "1.19.0",
@@ -1938,6 +1592,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.46.0.tgz",
       "integrity": "sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -1945,53 +1600,11 @@
         "node": ">=14"
       }
     },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.46.0.tgz",
-      "integrity": "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw==",
-      "dependencies": {
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
-      "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.19.0.tgz",
       "integrity": "sha512-+IRvUm+huJn2KqfFW3yW/cjvRwJ8Q7FzYHoUNx5Fr0Lws0LxjMJG1uVB8HDpLwm7mg5XXH2M5MF+0jj5cM8BpQ==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/resources": "1.19.0",
@@ -2008,6 +1621,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.19.0.tgz",
       "integrity": "sha512-TCiEq/cUjM15RFqBRwWomTVbOqzndWL4ILa7ZCu0zbjU1/XY6AgHkgrgAc7vGP6TjRqH4Xryuglol8tcIfbBUQ==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/context-async-hooks": "1.19.0",
         "@opentelemetry/core": "1.19.0",
@@ -2027,6 +1641,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2041,6 +1656,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
       "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -3970,9 +3586,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
+      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.2",
@@ -4364,14 +3980,14 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
-      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+      "version": "17.11.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.1.tgz",
+      "integrity": "sha512-671acnrx+w96PCcQOzvm0VYQVwNL2PVgZmDRaFuSsx8sIUmGzYElPw5lU8F3Cr0jOuPs1oM56p7W2a1cdDOwcw==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.4",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
@@ -5827,14 +5443,387 @@
         "mockotlpserver": "lib/cli.js"
       },
       "devDependencies": {
-        "@opentelemetry/auto-instrumentations-node": "^0.40.2",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.46.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.46.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.46.0",
-        "@opentelemetry/sdk-node": "^0.46.0"
+        "@opentelemetry/auto-instrumentations-node": "^0.40.3",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.47.0",
+        "@opentelemetry/sdk-node": "^0.47.0"
       },
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.20.0.tgz",
+      "integrity": "sha512-PNecg4zvRF5y5h3luK/hzUEmgZtZ8hbX19TMALj3SVShYS2MrDZG6uT27uLkAwACMfK9BP7/UyXXjND5lkaC2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/core": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.20.0.tgz",
+      "integrity": "sha512-lSRvk5AIdD6CtgYJcJXh0wGibQ3S/8bC2qbqKs9wK8e0K1tsWV6YkGFOqVc+jIRlCbZoIBeZzDe5UI+vb94uvg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.47.0.tgz",
+      "integrity": "sha512-cWy713Wb3WzuBDyhYiLONF2Ojmn6H2Agn/CiIerMypeMIFyhfO3fPm5cA1qSew+6s3115dwrXGw8kQLtfb/xlA==",
+      "dev": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.47.0.tgz",
+      "integrity": "sha512-TUSlzSHswJSWVxPx89oF6tOqT9tn+s7/15ED3Hi4Qa17CBmZbJxQ3Bn1j7F5kpBpyPOWjGSdSooOPYCgGsF6Jw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.47.0.tgz",
+      "integrity": "sha512-0gzOFQr//nh/BtlmYl2I5jhxsfvYkdHr7lluLS5I9M/dCxaZqZHeY7sZgop+g5WbTRAyK63q5BwrpyjbxdXnMg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.20.0.tgz",
+      "integrity": "sha512-CnbkOhvUebOzri1WyGkkdlWIj5AJAhEIRh/ubuT2V48NypXUUCnbrBKN1Aw4pj+wQAkPelYJ6cW42sBdBuOFPg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.47.0.tgz",
+      "integrity": "sha512-ZFhphFbowWwMahskn6BBJgMm8Z+TUx98IM+KpLIX3pwCK/zzgbCgwsJXRnjF9edDkc5jEhA7cEz/mP0CxfQkLA==",
+      "dev": true,
+      "dependencies": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "^1.7.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.47.0.tgz",
+      "integrity": "sha512-qkcWwy2oR7msLPukIFcP9OkUgLME2zQhEM+18h6RWgJJIjgVlKjt7p2JCap0uWI3K9pBO3eqRRX2U0p2k5e+aw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.47.0.tgz",
+      "integrity": "sha512-iejk7A+82fWpIvGA+rxi9MYGJLvu4e6DGhfJeBiUfrqLnyQEUUFAjprWTN85JuEJHMoqB7/IUiitve01vuNZQQ==",
+      "dev": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "protobufjs": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/otlp-proto-exporter-base": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.47.0.tgz",
+      "integrity": "sha512-SFVuzf3b7U9+5jfxqWrwsq/HlGF8CEKFe4avSFtEFpj8VOSRDOTYK6A641HEAHiQp/nTLlTHtV7djdp6ZyIUVw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "protobufjs": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.47.0.tgz",
+      "integrity": "sha512-0iPMbBoOaboUKVay2A6HXgEWXfL14+zbbywJSioQhVb3FWuO1oh8gvBo84Zra/rrYDLXwSlYBt+UmNXoTwAvXg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.20.0.tgz",
+      "integrity": "sha512-rDLcZGhhe+VoKKY77U5o5IW5D+OMoXg44GYmCn68Jx3O5TBGMJ2oZBcCxLgHlAA/ZdqkdRgQD0E40s8bXq41JA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.20.0.tgz",
+      "integrity": "sha512-JqdKlyyrgIinR8ZhMoJrL54AAHMDEACLLXYLnabzFTHeoBEsC36ZoO98hVucrpUvkDCJMvdVHH/4cvvj+boUzg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/resources": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.20.0.tgz",
+      "integrity": "sha512-nOpV0vGegSq+9ze2cEDvO3BMA5pGBhmhKZiAlj+xQZjiEjPmJtdHIuBLRvptu2ahcbFJw85gIB9BYHZOvZK1JQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.47.0.tgz",
+      "integrity": "sha512-s0ZEsFB0r4sZswicZ1WrT6/jVBTl83Wb92U6OGnsSxecCQ8Bc8gpk+75ZzxfIT6RJemVRPQY7rO3QmgeFbvNIg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.8.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.20.0.tgz",
+      "integrity": "sha512-07bFOQUrpN/Q5biJ/cuBePztKwkc1VGkFblZxAcVkuvCLDAPJfsyr0NNWegWeYe0bpGt1jmXScpUWnVD+t8Q0w==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/sdk-node": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.47.0.tgz",
+      "integrity": "sha512-xUkVKcg/GzMgGlZPN43U5rCQLnWe/IQLPcUBptsDFD/JW1C9i3D8MepoSDjNunrOPHKZgpSNzx09Qlyzs9RgSQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.20.0.tgz",
+      "integrity": "sha512-BAIZ0hUgnhdb3OBQjn1FKGz/Iwie4l+uOMKklP7FGh7PTqEAbbzDNMJKaZQh6KepF7Fq+CZDRKslD3yrYy2Tzw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.20.0.tgz",
+      "integrity": "sha512-3RRl4O63Wr/QyWhjreB7xilFhj3cQHWuMqESPwWHb7eJogNmjj1JQsRda/i8xj1Td4Bk+2ojC7aA8mwbKbEfPQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/propagator-jaeger": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/mockotlpserver/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.20.0.tgz",
+      "integrity": "sha512-3zLJJCgTKYpbqFX8drl8hOCHtdchELC+kGqlVcV4mHW1DiElTtv1Nt9EKBptTd1IfL56QkuYnWJ3DeHd2Gtu/A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/mockotlpserver/node_modules/import-in-the-middle": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.2.tgz",
+      "integrity": "sha512-coz7AjRnPyKW36J6JX5Bjz1mcX7MX1H2XsEGseVcnXMdzsAbbAu0HBZhiAem+3SAmuZdi+p8OwoB2qUpTRgjOQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "packages/mockotlpserver/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/opentelemetry-node": {
@@ -5842,9 +5831,9 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation-http": "^0.46.0",
-        "@opentelemetry/resources": "^1.19.0",
-        "@opentelemetry/sdk-node": "^0.46.0",
+        "@opentelemetry/instrumentation-http": "^0.47.0",
+        "@opentelemetry/resources": "^1.20.0",
+        "@opentelemetry/sdk-node": "^0.47.0",
         "safe-stable-stringify": "^2.4.3"
       },
       "devDependencies": {
@@ -5857,13 +5846,111 @@
         "node": ">=14"
       }
     },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.20.0.tgz",
+      "integrity": "sha512-PNecg4zvRF5y5h3luK/hzUEmgZtZ8hbX19TMALj3SVShYS2MrDZG6uT27uLkAwACMfK9BP7/UyXXjND5lkaC2w==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/core": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.20.0.tgz",
+      "integrity": "sha512-lSRvk5AIdD6CtgYJcJXh0wGibQ3S/8bC2qbqKs9wK8e0K1tsWV6YkGFOqVc+jIRlCbZoIBeZzDe5UI+vb94uvg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.47.0.tgz",
+      "integrity": "sha512-cWy713Wb3WzuBDyhYiLONF2Ojmn6H2Agn/CiIerMypeMIFyhfO3fPm5cA1qSew+6s3115dwrXGw8kQLtfb/xlA==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.47.0.tgz",
+      "integrity": "sha512-TUSlzSHswJSWVxPx89oF6tOqT9tn+s7/15ED3Hi4Qa17CBmZbJxQ3Bn1j7F5kpBpyPOWjGSdSooOPYCgGsF6Jw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.47.0.tgz",
+      "integrity": "sha512-0gzOFQr//nh/BtlmYl2I5jhxsfvYkdHr7lluLS5I9M/dCxaZqZHeY7sZgop+g5WbTRAyK63q5BwrpyjbxdXnMg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.20.0.tgz",
+      "integrity": "sha512-CnbkOhvUebOzri1WyGkkdlWIj5AJAhEIRh/ubuT2V48NypXUUCnbrBKN1Aw4pj+wQAkPelYJ6cW42sBdBuOFPg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
     "packages/opentelemetry-node/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.46.0.tgz",
-      "integrity": "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw==",
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.47.0.tgz",
+      "integrity": "sha512-ZFhphFbowWwMahskn6BBJgMm8Z+TUx98IM+KpLIX3pwCK/zzgbCgwsJXRnjF9edDkc5jEhA7cEz/mP0CxfQkLA==",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
+        "import-in-the-middle": "^1.7.2",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -5876,13 +5963,13 @@
       }
     },
     "packages/opentelemetry-node/node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.46.0.tgz",
-      "integrity": "sha512-t5cxgqfV9AcxVP00/OL1ggkOSZM57VXDpvlWaOidYyyfLKcUJ9e2fGbNwoVsGFboRDeH0iFo7gLA3EEvX13wCA==",
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.47.0.tgz",
+      "integrity": "sha512-YqzYt5fEoG3zjilCu6qPCnIcTLUufAuBdGZjnh65HaTtOSNYUoUJqYDzSKClcAn5DI4tz3ErdKb8o2O6ktHnHw==",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -5892,10 +5979,220 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.47.0.tgz",
+      "integrity": "sha512-qkcWwy2oR7msLPukIFcP9OkUgLME2zQhEM+18h6RWgJJIjgVlKjt7p2JCap0uWI3K9pBO3eqRRX2U0p2k5e+aw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.47.0.tgz",
+      "integrity": "sha512-iejk7A+82fWpIvGA+rxi9MYGJLvu4e6DGhfJeBiUfrqLnyQEUUFAjprWTN85JuEJHMoqB7/IUiitve01vuNZQQ==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "protobufjs": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/otlp-proto-exporter-base": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.47.0.tgz",
+      "integrity": "sha512-SFVuzf3b7U9+5jfxqWrwsq/HlGF8CEKFe4avSFtEFpj8VOSRDOTYK6A641HEAHiQp/nTLlTHtV7djdp6ZyIUVw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "protobufjs": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.47.0.tgz",
+      "integrity": "sha512-0iPMbBoOaboUKVay2A6HXgEWXfL14+zbbywJSioQhVb3FWuO1oh8gvBo84Zra/rrYDLXwSlYBt+UmNXoTwAvXg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.20.0.tgz",
+      "integrity": "sha512-rDLcZGhhe+VoKKY77U5o5IW5D+OMoXg44GYmCn68Jx3O5TBGMJ2oZBcCxLgHlAA/ZdqkdRgQD0E40s8bXq41JA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.20.0.tgz",
+      "integrity": "sha512-JqdKlyyrgIinR8ZhMoJrL54AAHMDEACLLXYLnabzFTHeoBEsC36ZoO98hVucrpUvkDCJMvdVHH/4cvvj+boUzg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/resources": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.20.0.tgz",
+      "integrity": "sha512-nOpV0vGegSq+9ze2cEDvO3BMA5pGBhmhKZiAlj+xQZjiEjPmJtdHIuBLRvptu2ahcbFJw85gIB9BYHZOvZK1JQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.47.0.tgz",
+      "integrity": "sha512-s0ZEsFB0r4sZswicZ1WrT6/jVBTl83Wb92U6OGnsSxecCQ8Bc8gpk+75ZzxfIT6RJemVRPQY7rO3QmgeFbvNIg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.8.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.20.0.tgz",
+      "integrity": "sha512-07bFOQUrpN/Q5biJ/cuBePztKwkc1VGkFblZxAcVkuvCLDAPJfsyr0NNWegWeYe0bpGt1jmXScpUWnVD+t8Q0w==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/sdk-node": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.47.0.tgz",
+      "integrity": "sha512-xUkVKcg/GzMgGlZPN43U5rCQLnWe/IQLPcUBptsDFD/JW1C9i3D8MepoSDjNunrOPHKZgpSNzx09Qlyzs9RgSQ==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.20.0.tgz",
+      "integrity": "sha512-BAIZ0hUgnhdb3OBQjn1FKGz/Iwie4l+uOMKklP7FGh7PTqEAbbzDNMJKaZQh6KepF7Fq+CZDRKslD3yrYy2Tzw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.20.0.tgz",
+      "integrity": "sha512-3RRl4O63Wr/QyWhjreB7xilFhj3cQHWuMqESPwWHb7eJogNmjj1JQsRda/i8xj1Td4Bk+2ojC7aA8mwbKbEfPQ==",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/propagator-jaeger": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/opentelemetry-node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.20.0.tgz",
+      "integrity": "sha512-3zLJJCgTKYpbqFX8drl8hOCHtdchELC+kGqlVcV4mHW1DiElTtv1Nt9EKBptTd1IfL56QkuYnWJ3DeHd2Gtu/A==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "packages/opentelemetry-node/node_modules/import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.2.tgz",
+      "integrity": "sha512-coz7AjRnPyKW36J6JX5Bjz1mcX7MX1H2XsEGseVcnXMdzsAbbAu0HBZhiAem+3SAmuZdi+p8OwoB2qUpTRgjOQ==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",
@@ -5930,57 +6227,506 @@
       "requires": {
         "@grpc/grpc-js": "^1.9.13",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/auto-instrumentations-node": "^0.40.2",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.46.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.46.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.46.0",
-        "@opentelemetry/sdk-node": "^0.46.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.40.3",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.47.0",
+        "@opentelemetry/sdk-node": "^0.47.0",
         "dashdash": "^2.0.0",
         "long": "^5.2.3",
         "protobufjs": "^7.2.5",
         "safe-stable-stringify": "^2.4.3"
+      },
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.20.0.tgz",
+          "integrity": "sha512-PNecg4zvRF5y5h3luK/hzUEmgZtZ8hbX19TMALj3SVShYS2MrDZG6uT27uLkAwACMfK9BP7/UyXXjND5lkaC2w==",
+          "dev": true,
+          "requires": {}
+        },
+        "@opentelemetry/core": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.20.0.tgz",
+          "integrity": "sha512-lSRvk5AIdD6CtgYJcJXh0wGibQ3S/8bC2qbqKs9wK8e0K1tsWV6YkGFOqVc+jIRlCbZoIBeZzDe5UI+vb94uvg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-grpc": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.47.0.tgz",
+          "integrity": "sha512-cWy713Wb3WzuBDyhYiLONF2Ojmn6H2Agn/CiIerMypeMIFyhfO3fPm5cA1qSew+6s3115dwrXGw8kQLtfb/xlA==",
+          "dev": true,
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+            "@opentelemetry/otlp-transformer": "0.47.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.47.0.tgz",
+          "integrity": "sha512-TUSlzSHswJSWVxPx89oF6tOqT9tn+s7/15ED3Hi4Qa17CBmZbJxQ3Bn1j7F5kpBpyPOWjGSdSooOPYCgGsF6Jw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-exporter-base": "0.47.0",
+            "@opentelemetry/otlp-transformer": "0.47.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.47.0.tgz",
+          "integrity": "sha512-0gzOFQr//nh/BtlmYl2I5jhxsfvYkdHr7lluLS5I9M/dCxaZqZHeY7sZgop+g5WbTRAyK63q5BwrpyjbxdXnMg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-exporter-base": "0.47.0",
+            "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+            "@opentelemetry/otlp-transformer": "0.47.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0"
+          }
+        },
+        "@opentelemetry/exporter-zipkin": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.20.0.tgz",
+          "integrity": "sha512-CnbkOhvUebOzri1WyGkkdlWIj5AJAhEIRh/ubuT2V48NypXUUCnbrBKN1Aw4pj+wQAkPelYJ6cW42sBdBuOFPg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0",
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
+        "@opentelemetry/instrumentation": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.47.0.tgz",
+          "integrity": "sha512-ZFhphFbowWwMahskn6BBJgMm8Z+TUx98IM+KpLIX3pwCK/zzgbCgwsJXRnjF9edDkc5jEhA7cEz/mP0CxfQkLA==",
+          "dev": true,
+          "requires": {
+            "@types/shimmer": "^1.0.2",
+            "import-in-the-middle": "^1.7.2",
+            "require-in-the-middle": "^7.1.1",
+            "semver": "^7.5.2",
+            "shimmer": "^1.2.1"
+          }
+        },
+        "@opentelemetry/otlp-exporter-base": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.47.0.tgz",
+          "integrity": "sha512-qkcWwy2oR7msLPukIFcP9OkUgLME2zQhEM+18h6RWgJJIjgVlKjt7p2JCap0uWI3K9pBO3eqRRX2U0p2k5e+aw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0"
+          }
+        },
+        "@opentelemetry/otlp-grpc-exporter-base": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.47.0.tgz",
+          "integrity": "sha512-iejk7A+82fWpIvGA+rxi9MYGJLvu4e6DGhfJeBiUfrqLnyQEUUFAjprWTN85JuEJHMoqB7/IUiitve01vuNZQQ==",
+          "dev": true,
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-exporter-base": "0.47.0",
+            "protobufjs": "^7.2.3"
+          }
+        },
+        "@opentelemetry/otlp-proto-exporter-base": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.47.0.tgz",
+          "integrity": "sha512-SFVuzf3b7U9+5jfxqWrwsq/HlGF8CEKFe4avSFtEFpj8VOSRDOTYK6A641HEAHiQp/nTLlTHtV7djdp6ZyIUVw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-exporter-base": "0.47.0",
+            "protobufjs": "^7.2.3"
+          }
+        },
+        "@opentelemetry/otlp-transformer": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.47.0.tgz",
+          "integrity": "sha512-0iPMbBoOaboUKVay2A6HXgEWXfL14+zbbywJSioQhVb3FWuO1oh8gvBo84Zra/rrYDLXwSlYBt+UmNXoTwAvXg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api-logs": "0.47.0",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-logs": "0.47.0",
+            "@opentelemetry/sdk-metrics": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0"
+          }
+        },
+        "@opentelemetry/propagator-b3": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.20.0.tgz",
+          "integrity": "sha512-rDLcZGhhe+VoKKY77U5o5IW5D+OMoXg44GYmCn68Jx3O5TBGMJ2oZBcCxLgHlAA/ZdqkdRgQD0E40s8bXq41JA==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0"
+          }
+        },
+        "@opentelemetry/propagator-jaeger": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.20.0.tgz",
+          "integrity": "sha512-JqdKlyyrgIinR8ZhMoJrL54AAHMDEACLLXYLnabzFTHeoBEsC36ZoO98hVucrpUvkDCJMvdVHH/4cvvj+boUzg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.20.0.tgz",
+          "integrity": "sha512-nOpV0vGegSq+9ze2cEDvO3BMA5pGBhmhKZiAlj+xQZjiEjPmJtdHIuBLRvptu2ahcbFJw85gIB9BYHZOvZK1JQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
+        "@opentelemetry/sdk-logs": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.47.0.tgz",
+          "integrity": "sha512-s0ZEsFB0r4sZswicZ1WrT6/jVBTl83Wb92U6OGnsSxecCQ8Bc8gpk+75ZzxfIT6RJemVRPQY7rO3QmgeFbvNIg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.20.0.tgz",
+          "integrity": "sha512-07bFOQUrpN/Q5biJ/cuBePztKwkc1VGkFblZxAcVkuvCLDAPJfsyr0NNWegWeYe0bpGt1jmXScpUWnVD+t8Q0w==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/sdk-node": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.47.0.tgz",
+          "integrity": "sha512-xUkVKcg/GzMgGlZPN43U5rCQLnWe/IQLPcUBptsDFD/JW1C9i3D8MepoSDjNunrOPHKZgpSNzx09Qlyzs9RgSQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api-logs": "0.47.0",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+            "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+            "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+            "@opentelemetry/exporter-zipkin": "1.20.0",
+            "@opentelemetry/instrumentation": "0.47.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-logs": "0.47.0",
+            "@opentelemetry/sdk-metrics": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0",
+            "@opentelemetry/sdk-trace-node": "1.20.0",
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.20.0.tgz",
+          "integrity": "sha512-BAIZ0hUgnhdb3OBQjn1FKGz/Iwie4l+uOMKklP7FGh7PTqEAbbzDNMJKaZQh6KepF7Fq+CZDRKslD3yrYy2Tzw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.20.0.tgz",
+          "integrity": "sha512-3RRl4O63Wr/QyWhjreB7xilFhj3cQHWuMqESPwWHb7eJogNmjj1JQsRda/i8xj1Td4Bk+2ojC7aA8mwbKbEfPQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/context-async-hooks": "1.20.0",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/propagator-b3": "1.20.0",
+            "@opentelemetry/propagator-jaeger": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0",
+            "semver": "^7.5.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.20.0.tgz",
+          "integrity": "sha512-3zLJJCgTKYpbqFX8drl8hOCHtdchELC+kGqlVcV4mHW1DiElTtv1Nt9EKBptTd1IfL56QkuYnWJ3DeHd2Gtu/A==",
+          "dev": true
+        },
+        "import-in-the-middle": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.2.tgz",
+          "integrity": "sha512-coz7AjRnPyKW36J6JX5Bjz1mcX7MX1H2XsEGseVcnXMdzsAbbAu0HBZhiAem+3SAmuZdi+p8OwoB2qUpTRgjOQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.8.2",
+            "acorn-import-assertions": "^1.9.0",
+            "cjs-module-lexer": "^1.2.2",
+            "module-details-from-path": "^1.0.3"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@elastic/opentelemetry-node": {
       "version": "file:packages/opentelemetry-node",
       "requires": {
         "@elastic/mockotlpserver": "*",
-        "@opentelemetry/instrumentation-http": "^0.46.0",
-        "@opentelemetry/resources": "^1.19.0",
-        "@opentelemetry/sdk-node": "^0.46.0",
+        "@opentelemetry/instrumentation-http": "^0.47.0",
+        "@opentelemetry/resources": "^1.20.0",
+        "@opentelemetry/sdk-node": "^0.47.0",
         "module-details-from-path": "^1.0.3",
         "safe-stable-stringify": "^2.4.3",
         "semver": "^7.5.4",
         "tape": "^5.7.2"
       },
       "dependencies": {
+        "@opentelemetry/context-async-hooks": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.20.0.tgz",
+          "integrity": "sha512-PNecg4zvRF5y5h3luK/hzUEmgZtZ8hbX19TMALj3SVShYS2MrDZG6uT27uLkAwACMfK9BP7/UyXXjND5lkaC2w==",
+          "requires": {}
+        },
+        "@opentelemetry/core": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.20.0.tgz",
+          "integrity": "sha512-lSRvk5AIdD6CtgYJcJXh0wGibQ3S/8bC2qbqKs9wK8e0K1tsWV6YkGFOqVc+jIRlCbZoIBeZzDe5UI+vb94uvg==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-grpc": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.47.0.tgz",
+          "integrity": "sha512-cWy713Wb3WzuBDyhYiLONF2Ojmn6H2Agn/CiIerMypeMIFyhfO3fPm5cA1qSew+6s3115dwrXGw8kQLtfb/xlA==",
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+            "@opentelemetry/otlp-transformer": "0.47.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.47.0.tgz",
+          "integrity": "sha512-TUSlzSHswJSWVxPx89oF6tOqT9tn+s7/15ED3Hi4Qa17CBmZbJxQ3Bn1j7F5kpBpyPOWjGSdSooOPYCgGsF6Jw==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-exporter-base": "0.47.0",
+            "@opentelemetry/otlp-transformer": "0.47.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.47.0.tgz",
+          "integrity": "sha512-0gzOFQr//nh/BtlmYl2I5jhxsfvYkdHr7lluLS5I9M/dCxaZqZHeY7sZgop+g5WbTRAyK63q5BwrpyjbxdXnMg==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-exporter-base": "0.47.0",
+            "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+            "@opentelemetry/otlp-transformer": "0.47.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0"
+          }
+        },
+        "@opentelemetry/exporter-zipkin": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.20.0.tgz",
+          "integrity": "sha512-CnbkOhvUebOzri1WyGkkdlWIj5AJAhEIRh/ubuT2V48NypXUUCnbrBKN1Aw4pj+wQAkPelYJ6cW42sBdBuOFPg==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0",
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
         "@opentelemetry/instrumentation": {
-          "version": "0.46.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.46.0.tgz",
-          "integrity": "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw==",
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.47.0.tgz",
+          "integrity": "sha512-ZFhphFbowWwMahskn6BBJgMm8Z+TUx98IM+KpLIX3pwCK/zzgbCgwsJXRnjF9edDkc5jEhA7cEz/mP0CxfQkLA==",
           "requires": {
             "@types/shimmer": "^1.0.2",
-            "import-in-the-middle": "1.7.1",
+            "import-in-the-middle": "^1.7.2",
             "require-in-the-middle": "^7.1.1",
             "semver": "^7.5.2",
             "shimmer": "^1.2.1"
           }
         },
         "@opentelemetry/instrumentation-http": {
-          "version": "0.46.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.46.0.tgz",
-          "integrity": "sha512-t5cxgqfV9AcxVP00/OL1ggkOSZM57VXDpvlWaOidYyyfLKcUJ9e2fGbNwoVsGFboRDeH0iFo7gLA3EEvX13wCA==",
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.47.0.tgz",
+          "integrity": "sha512-YqzYt5fEoG3zjilCu6qPCnIcTLUufAuBdGZjnh65HaTtOSNYUoUJqYDzSKClcAn5DI4tz3ErdKb8o2O6ktHnHw==",
           "requires": {
-            "@opentelemetry/core": "1.19.0",
-            "@opentelemetry/instrumentation": "0.46.0",
-            "@opentelemetry/semantic-conventions": "1.19.0",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/instrumentation": "0.47.0",
+            "@opentelemetry/semantic-conventions": "1.20.0",
             "semver": "^7.5.2"
           }
         },
+        "@opentelemetry/otlp-exporter-base": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.47.0.tgz",
+          "integrity": "sha512-qkcWwy2oR7msLPukIFcP9OkUgLME2zQhEM+18h6RWgJJIjgVlKjt7p2JCap0uWI3K9pBO3eqRRX2U0p2k5e+aw==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0"
+          }
+        },
+        "@opentelemetry/otlp-grpc-exporter-base": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.47.0.tgz",
+          "integrity": "sha512-iejk7A+82fWpIvGA+rxi9MYGJLvu4e6DGhfJeBiUfrqLnyQEUUFAjprWTN85JuEJHMoqB7/IUiitve01vuNZQQ==",
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-exporter-base": "0.47.0",
+            "protobufjs": "^7.2.3"
+          }
+        },
+        "@opentelemetry/otlp-proto-exporter-base": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.47.0.tgz",
+          "integrity": "sha512-SFVuzf3b7U9+5jfxqWrwsq/HlGF8CEKFe4avSFtEFpj8VOSRDOTYK6A641HEAHiQp/nTLlTHtV7djdp6ZyIUVw==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/otlp-exporter-base": "0.47.0",
+            "protobufjs": "^7.2.3"
+          }
+        },
+        "@opentelemetry/otlp-transformer": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.47.0.tgz",
+          "integrity": "sha512-0iPMbBoOaboUKVay2A6HXgEWXfL14+zbbywJSioQhVb3FWuO1oh8gvBo84Zra/rrYDLXwSlYBt+UmNXoTwAvXg==",
+          "requires": {
+            "@opentelemetry/api-logs": "0.47.0",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-logs": "0.47.0",
+            "@opentelemetry/sdk-metrics": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0"
+          }
+        },
+        "@opentelemetry/propagator-b3": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.20.0.tgz",
+          "integrity": "sha512-rDLcZGhhe+VoKKY77U5o5IW5D+OMoXg44GYmCn68Jx3O5TBGMJ2oZBcCxLgHlAA/ZdqkdRgQD0E40s8bXq41JA==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0"
+          }
+        },
+        "@opentelemetry/propagator-jaeger": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.20.0.tgz",
+          "integrity": "sha512-JqdKlyyrgIinR8ZhMoJrL54AAHMDEACLLXYLnabzFTHeoBEsC36ZoO98hVucrpUvkDCJMvdVHH/4cvvj+boUzg==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.20.0.tgz",
+          "integrity": "sha512-nOpV0vGegSq+9ze2cEDvO3BMA5pGBhmhKZiAlj+xQZjiEjPmJtdHIuBLRvptu2ahcbFJw85gIB9BYHZOvZK1JQ==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
+        "@opentelemetry/sdk-logs": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.47.0.tgz",
+          "integrity": "sha512-s0ZEsFB0r4sZswicZ1WrT6/jVBTl83Wb92U6OGnsSxecCQ8Bc8gpk+75ZzxfIT6RJemVRPQY7rO3QmgeFbvNIg==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.20.0.tgz",
+          "integrity": "sha512-07bFOQUrpN/Q5biJ/cuBePztKwkc1VGkFblZxAcVkuvCLDAPJfsyr0NNWegWeYe0bpGt1jmXScpUWnVD+t8Q0w==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/sdk-node": {
+          "version": "0.47.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.47.0.tgz",
+          "integrity": "sha512-xUkVKcg/GzMgGlZPN43U5rCQLnWe/IQLPcUBptsDFD/JW1C9i3D8MepoSDjNunrOPHKZgpSNzx09Qlyzs9RgSQ==",
+          "requires": {
+            "@opentelemetry/api-logs": "0.47.0",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+            "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+            "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+            "@opentelemetry/exporter-zipkin": "1.20.0",
+            "@opentelemetry/instrumentation": "0.47.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/sdk-logs": "0.47.0",
+            "@opentelemetry/sdk-metrics": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0",
+            "@opentelemetry/sdk-trace-node": "1.20.0",
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.20.0.tgz",
+          "integrity": "sha512-BAIZ0hUgnhdb3OBQjn1FKGz/Iwie4l+uOMKklP7FGh7PTqEAbbzDNMJKaZQh6KepF7Fq+CZDRKslD3yrYy2Tzw==",
+          "requires": {
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/resources": "1.20.0",
+            "@opentelemetry/semantic-conventions": "1.20.0"
+          }
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.20.0.tgz",
+          "integrity": "sha512-3RRl4O63Wr/QyWhjreB7xilFhj3cQHWuMqESPwWHb7eJogNmjj1JQsRda/i8xj1Td4Bk+2ojC7aA8mwbKbEfPQ==",
+          "requires": {
+            "@opentelemetry/context-async-hooks": "1.20.0",
+            "@opentelemetry/core": "1.20.0",
+            "@opentelemetry/propagator-b3": "1.20.0",
+            "@opentelemetry/propagator-jaeger": "1.20.0",
+            "@opentelemetry/sdk-trace-base": "1.20.0",
+            "semver": "^7.5.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.20.0.tgz",
+          "integrity": "sha512-3zLJJCgTKYpbqFX8drl8hOCHtdchELC+kGqlVcV4mHW1DiElTtv1Nt9EKBptTd1IfL56QkuYnWJ3DeHd2Gtu/A=="
+        },
         "import-in-the-middle": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-          "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.2.tgz",
+          "integrity": "sha512-coz7AjRnPyKW36J6JX5Bjz1mcX7MX1H2XsEGseVcnXMdzsAbbAu0HBZhiAem+3SAmuZdi+p8OwoB2qUpTRgjOQ==",
           "requires": {
             "acorn": "^8.8.2",
             "acorn-import-assertions": "^1.9.0",
@@ -6282,302 +7028,77 @@
       "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw=="
     },
     "@opentelemetry/api-logs": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.45.1.tgz",
-      "integrity": "sha512-zVGq/k70l+kB/Wuv3O/zhptP2hvDhEbhDu9EtHde1iWZJf3FedeYS/nWVcMBkkyPAjS/JKNk86WN4CBQLGUuOw==",
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.47.0.tgz",
+      "integrity": "sha512-AR6UOVcWZkuibLR/7/OecYJasncAf6VstNV/KT5qHq1HShVFmJetcgim0KMog/ON23yHZQjT9GPVTwB0FEhPQA==",
       "requires": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "@opentelemetry/auto-instrumentations-node": {
-      "version": "0.40.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.40.2.tgz",
-      "integrity": "sha512-t47g+Vs1V+Vd8HIKfx8D7nbNXSvq1uDceMlWoWzPABhet7iTLFbrPqPakxw2MOru4T0n0phwlC8+/dLfV37QXg==",
+      "version": "0.40.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.40.3.tgz",
+      "integrity": "sha512-MgBCzpFU4FBQEsXPgt5driYzxErf2JGntQ8Amtc94sqrnvq+FKdEBa6vxOpZlPM+c4Xr6tPpAT1ecTBV8U87hw==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
-        "@opentelemetry/instrumentation-amqplib": "^0.33.4",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.37.3",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.37.1",
-        "@opentelemetry/instrumentation-bunyan": "^0.34.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.34.1",
-        "@opentelemetry/instrumentation-connect": "^0.32.3",
-        "@opentelemetry/instrumentation-cucumber": "^0.2.0",
-        "@opentelemetry/instrumentation-dataloader": "^0.5.3",
-        "@opentelemetry/instrumentation-dns": "^0.32.4",
-        "@opentelemetry/instrumentation-express": "^0.34.0",
-        "@opentelemetry/instrumentation-fastify": "^0.32.5",
-        "@opentelemetry/instrumentation-fs": "^0.8.3",
-        "@opentelemetry/instrumentation-generic-pool": "^0.32.4",
-        "@opentelemetry/instrumentation-graphql": "^0.36.0",
-        "@opentelemetry/instrumentation-grpc": "^0.45.1",
-        "@opentelemetry/instrumentation-hapi": "^0.33.2",
-        "@opentelemetry/instrumentation-http": "^0.45.1",
-        "@opentelemetry/instrumentation-ioredis": "^0.36.0",
-        "@opentelemetry/instrumentation-knex": "^0.32.3",
-        "@opentelemetry/instrumentation-koa": "^0.36.3",
-        "@opentelemetry/instrumentation-lru-memoizer": "^0.33.4",
-        "@opentelemetry/instrumentation-memcached": "^0.32.4",
-        "@opentelemetry/instrumentation-mongodb": "^0.38.0",
-        "@opentelemetry/instrumentation-mongoose": "^0.33.4",
-        "@opentelemetry/instrumentation-mysql": "^0.34.4",
-        "@opentelemetry/instrumentation-mysql2": "^0.34.4",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.33.3",
-        "@opentelemetry/instrumentation-net": "^0.32.4",
-        "@opentelemetry/instrumentation-pg": "^0.37.1",
-        "@opentelemetry/instrumentation-pino": "^0.34.4",
-        "@opentelemetry/instrumentation-redis": "^0.35.4",
-        "@opentelemetry/instrumentation-redis-4": "^0.35.5",
-        "@opentelemetry/instrumentation-restify": "^0.34.2",
-        "@opentelemetry/instrumentation-router": "^0.33.3",
-        "@opentelemetry/instrumentation-socket.io": "^0.34.4",
-        "@opentelemetry/instrumentation-tedious": "^0.6.4",
-        "@opentelemetry/instrumentation-winston": "^0.33.0",
-        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.4",
-        "@opentelemetry/resource-detector-aws": "^1.3.4",
-        "@opentelemetry/resource-detector-container": "^0.3.4",
-        "@opentelemetry/resource-detector-gcp": "^0.29.4",
+        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.33.5",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.37.4",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.37.2",
+        "@opentelemetry/instrumentation-bunyan": "^0.34.1",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.34.2",
+        "@opentelemetry/instrumentation-connect": "^0.32.4",
+        "@opentelemetry/instrumentation-cucumber": "^0.2.1",
+        "@opentelemetry/instrumentation-dataloader": "^0.5.4",
+        "@opentelemetry/instrumentation-dns": "^0.32.5",
+        "@opentelemetry/instrumentation-express": "^0.34.1",
+        "@opentelemetry/instrumentation-fastify": "^0.32.6",
+        "@opentelemetry/instrumentation-fs": "^0.8.4",
+        "@opentelemetry/instrumentation-generic-pool": "^0.32.5",
+        "@opentelemetry/instrumentation-graphql": "^0.36.1",
+        "@opentelemetry/instrumentation-grpc": "^0.46.0",
+        "@opentelemetry/instrumentation-hapi": "^0.33.3",
+        "@opentelemetry/instrumentation-http": "^0.46.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.36.1",
+        "@opentelemetry/instrumentation-knex": "^0.32.4",
+        "@opentelemetry/instrumentation-koa": "^0.36.4",
+        "@opentelemetry/instrumentation-lru-memoizer": "^0.33.5",
+        "@opentelemetry/instrumentation-memcached": "^0.32.5",
+        "@opentelemetry/instrumentation-mongodb": "^0.38.1",
+        "@opentelemetry/instrumentation-mongoose": "^0.34.0",
+        "@opentelemetry/instrumentation-mysql": "^0.34.5",
+        "@opentelemetry/instrumentation-mysql2": "^0.34.5",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.33.4",
+        "@opentelemetry/instrumentation-net": "^0.32.5",
+        "@opentelemetry/instrumentation-pg": "^0.37.2",
+        "@opentelemetry/instrumentation-pino": "^0.34.5",
+        "@opentelemetry/instrumentation-redis": "^0.35.5",
+        "@opentelemetry/instrumentation-redis-4": "^0.35.6",
+        "@opentelemetry/instrumentation-restify": "^0.34.3",
+        "@opentelemetry/instrumentation-router": "^0.33.4",
+        "@opentelemetry/instrumentation-socket.io": "^0.35.0",
+        "@opentelemetry/instrumentation-tedious": "^0.6.5",
+        "@opentelemetry/instrumentation-winston": "^0.33.1",
+        "@opentelemetry/resource-detector-alibaba-cloud": "^0.28.5",
+        "@opentelemetry/resource-detector-aws": "^1.3.5",
+        "@opentelemetry/resource-detector-container": "^0.3.5",
+        "@opentelemetry/resource-detector-gcp": "^0.29.5",
         "@opentelemetry/resources": "^1.12.0",
-        "@opentelemetry/sdk-node": "^0.45.1"
-      },
-      "dependencies": {
-        "@opentelemetry/context-async-hooks": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.18.1.tgz",
-          "integrity": "sha512-HHfJR32NH2x0b69CACCwH8m1dpNALoCTtpgmIWMNkeMGNUeKT48d4AX4xsF4uIRuUoRTbTgtSBRvS+cF97qwCQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@opentelemetry/core": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
-          "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.18.1"
-          }
-        },
-        "@opentelemetry/exporter-trace-otlp-grpc": {
-          "version": "0.45.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.45.1.tgz",
-          "integrity": "sha512-c/Wrn6LUqPiRgKhvMydau6kPz4ih6b/uwospiavjXju98ZfVv+KjaIF13cblW+4cQ6ZR3lm7t66umQfXrGBhPQ==",
-          "dev": true,
-          "requires": {
-            "@grpc/grpc-js": "^1.7.1",
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/otlp-grpc-exporter-base": "0.45.1",
-            "@opentelemetry/otlp-transformer": "0.45.1",
-            "@opentelemetry/resources": "1.18.1",
-            "@opentelemetry/sdk-trace-base": "1.18.1"
-          }
-        },
-        "@opentelemetry/exporter-trace-otlp-http": {
-          "version": "0.45.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.45.1.tgz",
-          "integrity": "sha512-a6CGqSG66n5R1mghzLMzyzn3iGap1b0v+0PjKFjfYuwLtpHQBxh2PHxItu+m2mXSwnM4R0GJlk9oUW5sQkCE0w==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/otlp-exporter-base": "0.45.1",
-            "@opentelemetry/otlp-transformer": "0.45.1",
-            "@opentelemetry/resources": "1.18.1",
-            "@opentelemetry/sdk-trace-base": "1.18.1"
-          }
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "version": "0.45.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.45.1.tgz",
-          "integrity": "sha512-8QI6QARxNP4y9RUpuQxXjw2HyRNyeuD9CWEhS5ON44Mt+XP7YbOZR3GLx2Ml2JZ8uzB5dd2EGlMgaMuZe36D5Q==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/otlp-exporter-base": "0.45.1",
-            "@opentelemetry/otlp-proto-exporter-base": "0.45.1",
-            "@opentelemetry/otlp-transformer": "0.45.1",
-            "@opentelemetry/resources": "1.18.1",
-            "@opentelemetry/sdk-trace-base": "1.18.1"
-          }
-        },
-        "@opentelemetry/exporter-zipkin": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.18.1.tgz",
-          "integrity": "sha512-RmoWVFXFhvIh3q4szUe8I+/vxuMR0HNsOm39zNxnWJcK7JDwnPra9cLY/M78u6bTgB6Fte8GKgU128vvDzz0Iw==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/resources": "1.18.1",
-            "@opentelemetry/sdk-trace-base": "1.18.1",
-            "@opentelemetry/semantic-conventions": "1.18.1"
-          }
-        },
-        "@opentelemetry/otlp-exporter-base": {
-          "version": "0.45.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.45.1.tgz",
-          "integrity": "sha512-Jvd6x8EwWGKEPWF4tkP4LpTPXiIkkafMNMvMJUfJd5DyNAftL1vAz+48jmi3URL2LMPkGryrvWPz8Tdu917gQw==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1"
-          }
-        },
-        "@opentelemetry/otlp-grpc-exporter-base": {
-          "version": "0.45.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.45.1.tgz",
-          "integrity": "sha512-81X4mlzaAFoQCSXCgvYoMFyTy3mBhf8DD3J8bjW6/PH/rGZPJJkyYW0/YzepMrmBZXqlKZpTOU1aJ8sebVvDvw==",
-          "dev": true,
-          "requires": {
-            "@grpc/grpc-js": "^1.7.1",
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/otlp-exporter-base": "0.45.1",
-            "protobufjs": "^7.2.3"
-          }
-        },
-        "@opentelemetry/otlp-proto-exporter-base": {
-          "version": "0.45.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.45.1.tgz",
-          "integrity": "sha512-jtDkly6EW8TZHpbPpwJV9YT5PgbtL5B2UU8zcyGDiLT1wkIAYjFJZ1AqWmROIpydu8ohMq0dRwe4u0izNMdHpA==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/otlp-exporter-base": "0.45.1",
-            "protobufjs": "^7.2.3"
-          }
-        },
-        "@opentelemetry/otlp-transformer": {
-          "version": "0.45.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.45.1.tgz",
-          "integrity": "sha512-FhIHgfC0b0XtoBrS5ISfva939yWffNl47ypXR8I7Ru+dunlySpmf2TLocKHYLHGcWiuoeSNO5O4dZCmSKOtpXw==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/api-logs": "0.45.1",
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/resources": "1.18.1",
-            "@opentelemetry/sdk-logs": "0.45.1",
-            "@opentelemetry/sdk-metrics": "1.18.1",
-            "@opentelemetry/sdk-trace-base": "1.18.1"
-          }
-        },
-        "@opentelemetry/propagator-b3": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.18.1.tgz",
-          "integrity": "sha512-oSTUOsnt31JDx5SoEy27B5jE1/tiPvvE46w7CDKj0R5oZhCCfYH2bbSGa7NOOyDXDNqQDkgqU1DIV/xOd3f8pw==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1"
-          }
-        },
-        "@opentelemetry/propagator-jaeger": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.18.1.tgz",
-          "integrity": "sha512-Kh4M1Qewv0Tbmts6D8LgNzx99IjdE18LCmY/utMkgVyU7Bg31Yuj+X6ZyoIRKPcD2EV4rVkuRI16WVMRuGbhWA==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
-          "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/semantic-conventions": "1.18.1"
-          }
-        },
-        "@opentelemetry/sdk-logs": {
-          "version": "0.45.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.45.1.tgz",
-          "integrity": "sha512-z0RRgW4LeKEKnhXS4F/HnqB6+7gsy63YK47F4XAJYHs4s1KKg8XnQ2RkbuL31i/a9nXkylttYtvsT50CGr487g==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/resources": "1.18.1"
-          }
-        },
-        "@opentelemetry/sdk-metrics": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.18.1.tgz",
-          "integrity": "sha512-TEFgeNFhdULBYiCoHbz31Y4PDsfjjxRp8Wmdp6ybLQZPqMNEb+dRq+XN8Xw3ivIgTaf9gYsomgV5ensX99RuEQ==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/resources": "1.18.1",
-            "lodash.merge": "^4.6.2"
-          }
-        },
-        "@opentelemetry/sdk-node": {
-          "version": "0.45.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.45.1.tgz",
-          "integrity": "sha512-VtYvlz2ydfJLuOUhCnGER69mz2KUYk3/kpbqI1FWlUP+kzTwivMuy7hIPPv6KmuOIMYWmW4lM+WyJACHqNvROw==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/api-logs": "0.45.1",
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/exporter-trace-otlp-grpc": "0.45.1",
-            "@opentelemetry/exporter-trace-otlp-http": "0.45.1",
-            "@opentelemetry/exporter-trace-otlp-proto": "0.45.1",
-            "@opentelemetry/exporter-zipkin": "1.18.1",
-            "@opentelemetry/instrumentation": "0.45.1",
-            "@opentelemetry/resources": "1.18.1",
-            "@opentelemetry/sdk-logs": "0.45.1",
-            "@opentelemetry/sdk-metrics": "1.18.1",
-            "@opentelemetry/sdk-trace-base": "1.18.1",
-            "@opentelemetry/sdk-trace-node": "1.18.1",
-            "@opentelemetry/semantic-conventions": "1.18.1"
-          }
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
-          "integrity": "sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/resources": "1.18.1",
-            "@opentelemetry/semantic-conventions": "1.18.1"
-          }
-        },
-        "@opentelemetry/sdk-trace-node": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.18.1.tgz",
-          "integrity": "sha512-ML0l9TNlfLoplLF1F8lb95NGKgdm6OezDS3Ymqav9sYxMd5bnH2LZVzd4xEF+ov5vpZJOGdWxJMs2nC9no7+xA==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/context-async-hooks": "1.18.1",
-            "@opentelemetry/core": "1.18.1",
-            "@opentelemetry/propagator-b3": "1.18.1",
-            "@opentelemetry/propagator-jaeger": "1.18.1",
-            "@opentelemetry/sdk-trace-base": "1.18.1",
-            "semver": "^7.5.2"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-          "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
+        "@opentelemetry/sdk-node": "^0.46.0"
       }
     },
     "@opentelemetry/context-async-hooks": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.19.0.tgz",
       "integrity": "sha512-0i1ECOc9daKK3rjUgDDXf0GDD5XfCou5lXnt2DALIc2qKoruPPcesobNKE54laSVUWnC3jX26RzuOa31g0V32A==",
+      "dev": true,
       "requires": {}
     },
     "@opentelemetry/core": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.19.0.tgz",
       "integrity": "sha512-w42AukJh3TP8R0IZZOVJVM/kMWu8g+lm4LzT70WtuKqhwq7KVhcDzZZuZinWZa6TtQCl7Smt2wolEYzpHabOgw==",
+      "dev": true,
       "requires": {
         "@opentelemetry/semantic-conventions": "1.19.0"
       }
@@ -6586,6 +7107,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.46.0.tgz",
       "integrity": "sha512-kR4kehnfIhv7v/2MuNYfrlh9A/ZtQofwCzurTIplornUjdzhKDGgjui1NkNTqTfM1QkqfCiavGsf5hwocx29bA==",
+      "dev": true,
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.19.0",
@@ -6599,6 +7121,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.46.0.tgz",
       "integrity": "sha512-vZ2pYOB+qrQ+jnKPY6Gnd58y1k/Ti//Ny6/XsSX7/jED0X77crtSVgC6N5UA0JiGJOh6QB2KE9gaH99010XHzg==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/otlp-exporter-base": "0.46.0",
@@ -6611,6 +7134,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.46.0.tgz",
       "integrity": "sha512-A7PftDM57w1TLiirrhi8ceAnCpYkpUBObELdn239IyYF67zwngImGfBLf5Yo3TTAOA2Oj1TL76L8zWVL8W+Suw==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/otlp-exporter-base": "0.46.0",
@@ -6624,6 +7148,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.19.0.tgz",
       "integrity": "sha512-TY1fy4JiOBN5a8T9fknqTMcz0DXIeFBr6sklaLCgwtj+G699a5R4CekNwpeM7DHSwC44UMX7gljO2I6dYsTS3A==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/resources": "1.19.0",
@@ -6632,13 +7157,13 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.45.1.tgz",
-      "integrity": "sha512-V1Cr0g8hSg35lpW3G/GYVZurrhHrQZJdmP68WyJ83f1FDn3iru+/Vnlto9kiOSm7PHhW+pZGdb9Fbv+mkQ31CA==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.46.0.tgz",
+      "integrity": "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw==",
       "dev": true,
       "requires": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.4.2",
+        "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -6656,23 +7181,23 @@
       }
     },
     "@opentelemetry/instrumentation-amqplib": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.33.4.tgz",
-      "integrity": "sha512-fL+WrEsIM3cP4VTOsqR8enlT/4VX+OCVF7WALN85bgdFPSRpv2X7ZqsXOdYd358cAp4KO9MiveSkAKwKcTXKLw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.33.5.tgz",
+      "integrity": "sha512-WQ/XPzNLOHL3fpsmgoQUkiKCkJ09hvPN8wGrGzzOHMiJ5/3LqvfvxsJ4Rcd6aWkA4il3hEfpl+V0VF0t/DP65A==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.37.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.37.3.tgz",
-      "integrity": "sha512-TlFeG0xZSMIg0CZwonpmrCrPHPfwSWbsg/P+NwY64i+jq0ysYfj/2trkHVDOUtC636FR1NaPLAuZBMVAMPhILA==",
+      "version": "0.37.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.37.4.tgz",
+      "integrity": "sha512-/wdZwUalIWAbxeycvmE+25c1xCMhe5EUuj8bN0MWWN3L8N2SYvfv6DmiRgwrTIPXRgIyFugh2udNiF4MezZN4Q==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -6680,76 +7205,87 @@
       }
     },
     "@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.37.1.tgz",
-      "integrity": "sha512-vIvA9LpxLMHx0sraBF+qyiGuiqeeLz2CKQPoV4bAlzd+Zlcwk3Yg/NHHjMvP7aCy1VB6cGS8UkMG5lNM1a1NmQ==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.37.2.tgz",
+      "integrity": "sha512-eFHHOk0P9EFQ9Ho+2w7KH9R8cH7hut0/ePSsrk0nAM6Tiq2lBPeHn8ialCWESAA9jSjy+iuDelwmqAEXEe+jrg==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
-        "@opentelemetry/propagation-utils": "^0.30.4",
+        "@opentelemetry/instrumentation": "^0.46.0",
+        "@opentelemetry/propagation-utils": "^0.30.5",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-bunyan": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.34.0.tgz",
-      "integrity": "sha512-UjuvggGrclyn6avTcMAdqLyrrTV26ufB73vPBPlEmA3a2dtYCS07zW82Kacxi5emZDpmHIk6zQE18DqCb/xfpA==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.34.1.tgz",
+      "integrity": "sha512-+eshbCFr2dkUYO2jCpbYGFC5hs94UCOsQRK1XqNOjeiNvQRtqvKYqk8ARwJBYBX+aW4J02jOliAHQUh/d7gYPg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/api-logs": "^0.45.1",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/api-logs": "^0.46.0",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@types/bunyan": "1.8.9"
+      },
+      "dependencies": {
+        "@opentelemetry/api-logs": {
+          "version": "0.46.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.46.0.tgz",
+          "integrity": "sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.34.1.tgz",
-      "integrity": "sha512-n2bjMeKctNpXYW/vHURMCOXm56HFgQiD4fyIWioUvLROaPunKDvQpJlCLS88QMQ3f3pz/fp8Bde6gXuciLePxQ==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.34.2.tgz",
+      "integrity": "sha512-wuzq7QQ9o7PJnzseblNfBcURtM+9AwO6e1m644QYtAb/6YRR6qg6gAmAipVeQu01H5BuHBFC/92svaAkdIV2WQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-connect": {
-      "version": "0.32.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.32.3.tgz",
-      "integrity": "sha512-5BK52mIjNuKgY/RV8h0GLmS4qunXqkCIL7NZ73dJ40pnKMA8jqF5D5A2tFjWkCCQ4BdYfAfyjjiA+uTGoL3ZGg==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.32.4.tgz",
+      "integrity": "sha512-oUGph9idncdnHlQMwdIs6m6mii7Kdp9PpHkM9roOZy71h+2vvf6+cVn45bs2unBbE2Vxho2i/049QQbaYKDYlw==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.36"
       }
     },
     "@opentelemetry/instrumentation-cucumber": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.2.0.tgz",
-      "integrity": "sha512-2YWTeSrBrpTCvLoSka/ZkEl0I2YkwKrxi13d3xQqbEySJyyLnxrYoFkPhTn7uqhKOEwnh1B8MXunNXhMyei29Q==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.2.1.tgz",
+      "integrity": "sha512-ydF0DpmE0D6wccAbxx1F+6kokzcSSRy3X78Bvgok/3fHUSSshGLErqNiQL1HV44OIcV6392P3tu/jtXtUq3UDQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-dataloader": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.5.3.tgz",
-      "integrity": "sha512-tHpLbcjtdiDFLHFfYjmyKjnDYCQLmp6ceflsA9H4BEEwSE2p5ZW512TQl3abzb3EQK2V7+I1gqIuMGHKxmKIlg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.5.4.tgz",
+      "integrity": "sha512-l1qQvvygxZJw+S+4hgYgzvT4GArqBrar42wzB5LVsOy04+gmbDw/4y7IqxZYepFyXKuBownGS8pR4huRL/Tj/A==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       }
     },
     "@opentelemetry/instrumentation-dns": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.32.4.tgz",
-      "integrity": "sha512-04DTRKFDEpKgYpCqPGlnpCS0atuRUmAPj35xNGV/H7bZTCA3ZR77NeR3f4tYVfqlnsi3KiM1HzgrhwNBskVIEw==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.32.5.tgz",
+      "integrity": "sha512-fHJqrbezpZSipo4O9nF9yGq6R8oyr1W2gSlyk1foJNXBaqdCODTlzIa7BP50vGtLBN/m+qO8pMOWCJmYSBX35g==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.5.4"
       },
@@ -6766,114 +7302,91 @@
       }
     },
     "@opentelemetry/instrumentation-express": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.34.0.tgz",
-      "integrity": "sha512-wgMKa9vaCWAsgu/dNZwbRM1/6RusKZ7yWdlPhTzeI9RNE13we+KYIQKA1YFGuTypRMRTixwrJLHdy927y0TjAA==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.34.1.tgz",
+      "integrity": "sha512-pQBQxXpkH6imvzwCdPcw2FKjB1cphoRpmWTiGi6vtBdKXCP0hpne613ycpwhGG7C17S+mbarVmukbJKR4rmh6Q==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-fastify": {
-      "version": "0.32.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.5.tgz",
-      "integrity": "sha512-u88jctr2Y04N8ALpO448s6IH5F0RB3XXa8+fJ+SMh0JsDwpX4oJZGjbnXSKZP0Gl9FscWIENasNoedW+R2vaHw==",
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.6.tgz",
+      "integrity": "sha512-UkBu8rAqeVC034jsRMiEAmYhFQ03pvmE/MnoPKE9gAbgVtPILdekHYqAKM0MdqnEjW7pO45t4wWsbtIcN0eiBw==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-fs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.8.3.tgz",
-      "integrity": "sha512-o5uy91VAvXl1i71/AH3C6KV/6KQVGsnuNmjfUAJo4QqY2ta0Uzlpa0wy0nXvQUAP/3QbTx7NcF3rk3mVxLmgeg==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.8.4.tgz",
+      "integrity": "sha512-g99963nK8TuisUM3KH+ee5hOCHdCHSKiAdmy0RMdiKT7ITh3rXUct7fghQibViQA7FVPkdwM9+uRKkigJSFS9w==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.32.4.tgz",
-      "integrity": "sha512-NDNzoZ0MCmHeMQRxm1eL0l8fCoHIYFiugu5AZ4wt+S2wbgyh5BCd+ZAqTzSFEJGKGg7KZMfHgVRTiCsj+ljfvA==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.32.5.tgz",
+      "integrity": "sha512-MNFloXa3SDg/rHh397JnWADr7iYQ6HHRwT7ZId5Vt0L1Xx+Qp3XSIILsXk5qTXVUIytEIVgn8iMT+kZILHzSqg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-graphql": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.36.0.tgz",
-      "integrity": "sha512-H5nezZCV4HUjmPi4o2QlFXGzvldZiJ7hAEldy+37qMmm5PaqLmFW4w084/C+4IdPoxm4gJRtI8vkXJQJqqyktQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.36.1.tgz",
+      "integrity": "sha512-EOvaS+d2909TOJJjNTsb0vHaLg8WdTLoQS8bRKdy3lMgdd7I4OL9/LSC7dp4M8CvJKz9B464Ix9PnARvhMkNOw==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.45.1.tgz",
-      "integrity": "sha512-KyssKMi+cMAWc+9buGs7nHjnHm4wQPH99etunFblZCKQlzgPB+s8Q6aIlJ3LCkCaOGAhofpr4IkWh7dMcapJJQ==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.46.0.tgz",
+      "integrity": "sha512-KemIpB4jmywQv/+MbVoUIMVp3vr+rzra37TYbN7kTsbrn213YlzdXVamf6nq/yChI6q+9JlUnCdSZf86D6NO6g==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "0.45.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
-      },
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-          "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-          "dev": true
-        }
+        "@opentelemetry/instrumentation": "0.46.0",
+        "@opentelemetry/semantic-conventions": "1.19.0"
       }
     },
     "@opentelemetry/instrumentation-hapi": {
-      "version": "0.33.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.33.2.tgz",
-      "integrity": "sha512-XSe1/emVguKMEiV+ctva+Z9GI/3scPBwtNFAVcJFpM4ekK0SiIF73uBKmaC0mVnU+TIToPlkOC7nbkEbXq6y1g==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.33.3.tgz",
+      "integrity": "sha512-l14u1TFPXMUjfHqnrHtzuMyLq6V8BikwhYJO/hIgkbaPCxS38TloCtDLJvcs8S8AZlcQfkUqE/NFgXYETZRo+Q==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.13"
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.45.1.tgz",
-      "integrity": "sha512-ph7kv38Lipg/ggvoNJrwc3RCceLnTkVZwRbE5iu6w7fGsMjjc9jwlSmaOXKxUJjIimil2hL1qBm8xg2lmOVwxg==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.46.0.tgz",
+      "integrity": "sha512-t5cxgqfV9AcxVP00/OL1ggkOSZM57VXDpvlWaOidYyyfLKcUJ9e2fGbNwoVsGFboRDeH0iFo7gLA3EEvX13wCA==",
       "dev": true,
       "requires": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/instrumentation": "0.45.1",
-        "@opentelemetry/semantic-conventions": "1.18.1",
+        "@opentelemetry/core": "1.19.0",
+        "@opentelemetry/instrumentation": "0.46.0",
+        "@opentelemetry/semantic-conventions": "1.19.0",
         "semver": "^7.5.2"
       },
       "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
-          "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.18.1"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-          "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
-          "dev": true
-        },
         "semver": {
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -6886,132 +7399,132 @@
       }
     },
     "@opentelemetry/instrumentation-ioredis": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.36.0.tgz",
-      "integrity": "sha512-LmEHE3w8JzPpm2TEPiwjAjOSIPWM6t39TFNXu796IJba35k0ZZG9qQRaxv8CS61EZIT1eH7qgExHwEmPHsOl8Q==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.36.1.tgz",
+      "integrity": "sha512-xxab7n4TD5igCFR5N0j5PJFYVeOXm54ZtCARVS32xavwGyGf+Sb6VtuVCLdl0re4JENCg18FO97Dyb1ql2EBUA==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
       }
     },
     "@opentelemetry/instrumentation-knex": {
-      "version": "0.32.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.32.3.tgz",
-      "integrity": "sha512-8+JvZ1Gs9pMe6pgQfMVjth52WCUuKUu0L0tx237VAA53HHUtsCNPznBHp2EAlsLGSLLptfPvzXz/Bdp009ja8w==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.32.4.tgz",
+      "integrity": "sha512-vqxK1wqhktQnBA7nGr6nqfhV5irSXK9v0R29hqlyTr/cB/86Hn3Z98zH58QvHo131FcE+d70QdiXu3P9S5vq4g==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-koa": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.36.3.tgz",
-      "integrity": "sha512-ffn76qSuGUUtEBc8IZ1RHc//Y10ZKHku4QjPlpZY5/BtEd2xMV4iXmMdeJngKFiHrVKCvreyC5ON5hHcaQp32g==",
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.36.4.tgz",
+      "integrity": "sha512-Qt6IF0mo3FZZ+x4NQhv/pViDtPSw/h/QYDvyIqMCuqUibqta619WLUCwAcanKnZWvzMuYh6lT0TnZ8ktjXo6jQ==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.9",
         "@types/koa__router": "12.0.3"
       }
     },
     "@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.33.4.tgz",
-      "integrity": "sha512-SOO9y15z27n5VpjjHiT1r1H+uNxBHRaHX1z6DhGG0BjaJkyu9p6CSjXhsXu2gsAoubRKMSAd0Q+axf1MiVqhvw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.33.5.tgz",
+      "integrity": "sha512-vbm9QPEYD3FZNGSa+7xQ7uOkgbJtskIwp1KnsCpmdBBiulhBaqqgeNLFo7gd8UxMrI2Vu3LTlZil2D0dVt8g/A==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       }
     },
     "@opentelemetry/instrumentation-memcached": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.32.4.tgz",
-      "integrity": "sha512-q9uswokVrtgKFiVNb3QoTFFulXiHpm6FDOvI/3uO8/TnhhpUh776EuD5kDI0YWZ3J+gkN2Dj82KrmOfqBS5o1A==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.32.5.tgz",
+      "integrity": "sha512-1MS9LfgZruAsWOHVDTI+/Wy9mFFivUlpGUwYC4D+ho1I4NUyE33XHwL1BKcjMupkuRnE0JmbhdBfTG9Ai1vFkw==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       }
     },
     "@opentelemetry/instrumentation-mongodb": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.38.0.tgz",
-      "integrity": "sha512-nIepSpS3zQsJuDRRjZXMPvnUT7u3xn/+tWKnGB5jIQOstK5O1Nd6pkiPzi1VUmLDBJ1o31N+388mAxSpEqve0g==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.38.1.tgz",
+      "integrity": "sha512-X6YjE8dOCf8lG8FGmoAvczZq7LtgYaRzZcLGthZSUJQ2rfp1JJRlJixc+COvhrn1HJj5ab+AsSdUQgTpfQgEHQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-mongoose": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.33.4.tgz",
-      "integrity": "sha512-qPwurJjzxJVIzvlRmN4KADQ+BeD2KsDcEH7fMRPMZ35R90+0fQO3RFmINaO5zUpmYY1tHsw3zhnQVD23Dq+pfA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.34.0.tgz",
+      "integrity": "sha512-/wGNK7qR/QXpcidXntKsnfACHETp8G/f2o/k8FPvJ2lukvdM9r7cHLys8QwkJkTN8Kt3qG1VIwarGKYtE/zOSw==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-mysql": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.34.4.tgz",
-      "integrity": "sha512-LWpCGoKuSoHYIzI/SN3unkNkthdFHGyA3vJJWPmtLPxEP9qtCc2gAJUQQ6Q+73YJmHZdXlZSe7sOqGdKx/KyjQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.34.5.tgz",
+      "integrity": "sha512-cE8z1uJTeLcMj+R31t1pLkLqt3ryGMl1HApxsqqf8YCSHetrkVwGZOcyQ3phfgGSaNlC4/pdf3CQqfjhXbLWlA==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.22"
       }
     },
     "@opentelemetry/instrumentation-mysql2": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.34.4.tgz",
-      "integrity": "sha512-pgf7UUMiQFUbfzj2WkjOdzT8IoffsqlAbIdMobyAc2Ca90fIYrpEeIpurkzDJWsw1x4GaQRXmJuERhccgr5BSg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.34.5.tgz",
+      "integrity": "sha512-Ai3+cJ83b11kLypIVEPLHuYCiIQjf828hHJPpllr78EhmHiq4S1yTW34aP3BzCBY+5Adr5PS5Nnv7NLBI/YfaQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0"
       }
     },
     "@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.33.3.tgz",
-      "integrity": "sha512-B5v8Qi0chpHHgp/BeL5EcxQnnjm6OTYiMlGk6rM5X/xz9AdB60fAIXWerKKrG1QQ8JVcS5O4nhP4NzPC0JLjWw==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.33.4.tgz",
+      "integrity": "sha512-AynD6TesE0bZg9UzS4ZLG//6TmU8GkRrjubhxs7jYZ3JRAlJAq1In0zSwM082JOIs7wr286nhs1FmqK91cG1cg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-net": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.32.4.tgz",
-      "integrity": "sha512-sZUELN+pO73Mo2zXOt9pTrmwsVtf/WvOOjh+ItFYth4X5syOcHA192NvoEPLqIgWv0L5Iipm8M2SiWZiWm2X7w==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.32.5.tgz",
+      "integrity": "sha512-omBLTXyJeCtBy1MzVi+IzUcpXiup90k0z3AGhNKbzro4RhpsdMpN9O+3zZCXCIHMuyifhy7z8w99wmvvFO/FCQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-pg": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.37.1.tgz",
-      "integrity": "sha512-yJcTdwsnFqHLFR+uaS2mIvXfHnlzSD2VWgSvka9Y3SSZepcpiEbVs9G897p0XVNpNImo4+CfhOD6Mh5kL6o7Vg==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.37.2.tgz",
+      "integrity": "sha512-MAiKqdtGItYjvD6rOCyGS27CdMaDnh2JuImIHXhrPjq/sb2JlBNm6m1e4BH4uik1VfcKt/I3pI3UkydSWIscCg==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0",
         "@types/pg": "8.6.1",
@@ -7019,91 +7532,92 @@
       }
     },
     "@opentelemetry/instrumentation-pino": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.34.4.tgz",
-      "integrity": "sha512-cD4PssCNjOqc0h1vFLqIDYR8ajqwuOZfp3rk5dTyeiroUmfs6wzd4wc/Sfe/pVPsGkx+nRiFdfbpW1+DtZGHAg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.34.5.tgz",
+      "integrity": "sha512-auYDSeFhkPFXayT/060mQRL7O88Bt5NKcV0qOfquNa9J5/qs5dlJYdTOraxPrjiGPM3tHaAJ+AvAhR0CPYgZew==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       }
     },
     "@opentelemetry/instrumentation-redis": {
-      "version": "0.35.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.4.tgz",
-      "integrity": "sha512-MNO/cuHQMeafNu+K8PdrZDGPjWLsQTmyfJzzjasQgm6ELe+/6deNZzsAXkRK4e4sx+FJH7NDnyyqti/dhB4IeQ==",
+      "version": "0.35.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.5.tgz",
+      "integrity": "sha512-UPYUncDlLqDPtyU11UhyZOUxAyPQS6yQGT0b96KjpqMhmuRb3b0WxzZh3SoIaAyprL5f9fxyeV2HfSulR0aWFQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-redis-4": {
-      "version": "0.35.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.35.5.tgz",
-      "integrity": "sha512-+CuWyS1QOc/RYGSyLr/3VkXiNVU4rstsJi+b5j1sh4Mzy4sIrOtRQRcl74PXh06vOnSyGTToyQ9n4BKZuHODbQ==",
+      "version": "0.35.6",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.35.6.tgz",
+      "integrity": "sha512-OVSUJZAuy6OX18X2TKPdPlpwM5t4FooJU9QXiUxezhdMvfIAu00Agchw+gRbszkM7nvQ9dkXFOZO3nTmJNcLcA==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-restify": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.34.2.tgz",
-      "integrity": "sha512-W9fZJ6hH7PNIhzcKcmFjUgU87vnM1gPa/YTW724lZ9ItHPUol4wAcnv/F88xM+eouuZKLmCaCahZYp0tx7D/Ig==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.34.3.tgz",
+      "integrity": "sha512-nUqf4RTcQyc/YTWMT0e/ZqvuQqhRH04MOoSwaH6ocmyrEhKdPDq9AbvSMerQ/AxNC9yju/PytgzFFWH45hh3KA==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-router": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.33.3.tgz",
-      "integrity": "sha512-LbD+9YBx4SKK10WQ06s2iy9/tN9lQmlgneqem46WKi8rX0W2vo1VX5TEM+Bvn7d5lM5uaPDFGosQR++g52BSDQ==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.33.4.tgz",
+      "integrity": "sha512-4140BgILsL0H8tA0BBN2tjzajgjxlDqd4xPatk2i5q9ofy8wlB0BlDJ4m36U7G1z0v+a+LshQSNqPP2VHZ9ORw==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-socket.io": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.34.4.tgz",
-      "integrity": "sha512-r56esRFNEULo8p4iJ0xsd3JkzUPPtLrIeiX0YnqI5hzaoOz3bmUO7qu6/iiEX9/Ej9/rL0U5ZaEIEmagJIUcIw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.35.0.tgz",
+      "integrity": "sha512-ED1/Wco05H9fepKqX7n2kONq9EXxkBZTKS29nUH9vVL7wSIT8sBIDqpHz94CnQ8xuicaQQ7c5h9TVuhjtzV43Q==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-tedious": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.6.4.tgz",
-      "integrity": "sha512-bjoagT4AO26QXpv7bE4Vyrwcqxq0ntA2pWCLDHuXRnlt+iWyQm4dS/ExjQR4OuO8aRgeuk/3YC7dSl1rtdO7Kg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.6.5.tgz",
+      "integrity": "sha512-jjdrDegLUodz9np0yKCAa7sLxlAGTsxM7wU7l1mQ2NM6PHAGv4X3eSFClUk3fOipLx4+r5jTLnlsgu7g9CW+Qw==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1",
+        "@opentelemetry/instrumentation": "^0.46.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/tedious": "^4.0.10"
       }
     },
     "@opentelemetry/instrumentation-winston": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.33.0.tgz",
-      "integrity": "sha512-kf4GC6/IVDt+XumUZ54kB3G+1Kc3TfaLY63uZ+9Qi25LBPeBSYJHQugSvxZ9mK/5Uyf9rPxW2FevjblNyaY54w==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.33.1.tgz",
+      "integrity": "sha512-4tSORoAY9f+yzqNVGcGr/3GydPMfgSiKK1OESc+qBwVTz0bmz4cOrhCruCngGzoqDCmPYpwqwR/8j4wRKgcUpw==",
       "dev": true,
       "requires": {
-        "@opentelemetry/instrumentation": "^0.45.1"
+        "@opentelemetry/instrumentation": "^0.46.0"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.46.0.tgz",
       "integrity": "sha512-hfkh7cG17l77ZSLRAogz19SIJzr0KeC7xv5PDyTFbHFpwwoxV/bEViO49CqUFH6ckXB63NrltASP9R7po+ahTQ==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0"
       }
@@ -7112,6 +7626,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.46.0.tgz",
       "integrity": "sha512-/KB/xfZZiWIY2JknvCoT/e9paIzQO3QCBN5gR6RyxpXM/AGx3YTAOKvB/Ts9Va19jo5aE74gB7emhFaCNy4Rmw==",
+      "dev": true,
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.19.0",
@@ -7123,6 +7638,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.46.0.tgz",
       "integrity": "sha512-rEJBA8U2AxfEzrdIUcyyjOweyVFkO6V1XAxwP161JkxpvNuVDdULHAfRVnGtoZhiVA1XsJKcpIIq2MEKAqq4cg==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/otlp-exporter-base": "0.46.0",
@@ -7133,6 +7649,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.46.0.tgz",
       "integrity": "sha512-Fj9hZwr6xuqgsaERn667Uf6kuDG884puWhyrai2Jen2Fq+bGf4/5BzEJp/8xvty0VSU4EfXOto/ys3KpSz2UHg==",
+      "dev": true,
       "requires": {
         "@opentelemetry/api-logs": "0.46.0",
         "@opentelemetry/core": "1.19.0",
@@ -7146,6 +7663,7 @@
           "version": "0.46.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.46.0.tgz",
           "integrity": "sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==",
+          "dev": true,
           "requires": {
             "@opentelemetry/api": "^1.0.0"
           }
@@ -7153,9 +7671,9 @@
       }
     },
     "@opentelemetry/propagation-utils": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.4.tgz",
-      "integrity": "sha512-drYvwfhdXZ6ax5xnpuEQ/0C0AaCcxXcf47wZFNIK4DZu2RJmGk24XUSGWg5XI9gMKBe5qwXWBh9aSlSLWdA/Ww==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.5.tgz",
+      "integrity": "sha512-9ENyx6ptmjyYzL7le3FXk/lJc3cFFTrh9Y/ubO9velQZ64BdjpF9kOMJN3Z8KLJFVt66HYoWy9xlWoSIfS/ICg==",
       "dev": true,
       "requires": {}
     },
@@ -7172,6 +7690,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.19.0.tgz",
       "integrity": "sha512-v7y5IBOKBm0vP3yf0DHzlw4L2gL6tZ0KeeMTaxfO5IuomMffDbrGWcvYFp0Dt4LdZctTSK523rVLBB9FBHBciQ==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0"
       }
@@ -7180,6 +7699,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.19.0.tgz",
       "integrity": "sha512-dedkOoTzKg+nYoLWCMp0Im+wo+XkTRW6aXhi8VQRtMW/9SNJGOllCJSu8llToLxMDF0+6zu7OCrKkevAof2tew==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0"
       }
@@ -7191,9 +7711,9 @@
       "dev": true
     },
     "@opentelemetry/resource-detector-alibaba-cloud": {
-      "version": "0.28.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.4.tgz",
-      "integrity": "sha512-acesz8NgW6asYZNWJvLT/PwaM18iFaVgiEkhPEVtAberyl9+l+e8FBSvCFgV6KSAPnBMbdv11dkN1dSAAqqREg==",
+      "version": "0.28.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.5.tgz",
+      "integrity": "sha512-cobe2I0c5a66d98nCBprEB5erN5S0PTRrs49qSOnuTT2dC90nwSo2WDcSBfeDSKZH/7sB686P7FyKefWjQzhoA==",
       "dev": true,
       "requires": {
         "@opentelemetry/resources": "^1.0.0",
@@ -7201,9 +7721,9 @@
       }
     },
     "@opentelemetry/resource-detector-aws": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.4.tgz",
-      "integrity": "sha512-G6QK5kcLbqxF4zNFfuXyqZtWecNzwKVVqo/gEXlF3EZSIImPH2bGkElL8HpW9OGktWCqbbjYRTSo8VEjs6PxWA==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.5.tgz",
+      "integrity": "sha512-0GZJi8m6czksDJwpndSYJpnaPaFe83nEQVg4UnTTwB0cxKtrjpaarWDI46X0BuCX4bGp0M8pvI7f0rBt+LsIhA==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.0.0",
@@ -7212,9 +7732,9 @@
       }
     },
     "@opentelemetry/resource-detector-container": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.4.tgz",
-      "integrity": "sha512-p04SnseEk5P18T+90LscSdMYmehrn+paoLgE3s0BEusA+FDail1jRD0SsnoTHO94SM0XePIeaG6ip2n4Id9+8Q==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.5.tgz",
+      "integrity": "sha512-yLGLueH63DE9/WmDrizleqtT0uCOsslNqW+AcwzMHW7t8c2MtoJ7msgIsmi7tz5kxJgG8o54CnvXxobcwBhLCQ==",
       "dev": true,
       "requires": {
         "@opentelemetry/resources": "^1.0.0",
@@ -7222,9 +7742,9 @@
       }
     },
     "@opentelemetry/resource-detector-gcp": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.4.tgz",
-      "integrity": "sha512-YoUYYwjcCRRxkHHFco29Hli+dVrIPMDTkJqQ0BaH4MDkfFg4HEbO/WarNHxSv5wAIl3SiI4sYyNJ6qfK5Z92zQ==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.5.tgz",
+      "integrity": "sha512-cYckfRDDNX/nhiMF7fFooOCb/EObydNXWi0HwuPELHYa7heBCkWgTtNxs/PzuP46+FqDjuBcJL6beS2Ef7MyWg==",
       "dev": true,
       "requires": {
         "@opentelemetry/core": "^1.0.0",
@@ -7237,6 +7757,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.19.0.tgz",
       "integrity": "sha512-RgxvKuuMOf7nctOeOvpDjt2BpZvZGr9Y0vf7eGtY5XYZPkh2p7e2qub1S2IArdBMf9kEbz0SfycqCviOu9isqg==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/semantic-conventions": "1.19.0"
@@ -7246,6 +7767,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.46.0.tgz",
       "integrity": "sha512-Knlyk4+G72uEzNh6GRN1Fhmrj+/rkATI5/lOrevN7zRDLgp4kfyZBGGoWk7w+qQjlYvwhIIdPVxlIcipivdZIg==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/resources": "1.19.0"
@@ -7255,6 +7777,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.19.0.tgz",
       "integrity": "sha512-FiMii40zr0Fmys4F1i8gmuCvbinBnBsDeGBr4FQemOf0iPCLytYQm5AZJ/nn4xSc71IgKBQwTFQRAGJI7JvZ4Q==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/resources": "1.19.0",
@@ -7265,6 +7788,7 @@
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.46.0.tgz",
       "integrity": "sha512-BQhzdCRZXchhKjZaFkgxlgoowjOt/QXekJ1CZgfvFO9Yg5GV15LyJFUEyQkDyD8XbshGo3Cnj0WZMBnDWtWY1A==",
+      "dev": true,
       "requires": {
         "@opentelemetry/api-logs": "0.46.0",
         "@opentelemetry/core": "1.19.0",
@@ -7285,39 +7809,9 @@
           "version": "0.46.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.46.0.tgz",
           "integrity": "sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==",
+          "dev": true,
           "requires": {
             "@opentelemetry/api": "^1.0.0"
-          }
-        },
-        "@opentelemetry/instrumentation": {
-          "version": "0.46.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.46.0.tgz",
-          "integrity": "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw==",
-          "requires": {
-            "@types/shimmer": "^1.0.2",
-            "import-in-the-middle": "1.7.1",
-            "require-in-the-middle": "^7.1.1",
-            "semver": "^7.5.2",
-            "shimmer": "^1.2.1"
-          }
-        },
-        "import-in-the-middle": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-          "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
-          "requires": {
-            "acorn": "^8.8.2",
-            "acorn-import-assertions": "^1.9.0",
-            "cjs-module-lexer": "^1.2.2",
-            "module-details-from-path": "^1.0.3"
-          }
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "requires": {
-            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -7326,6 +7820,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.19.0.tgz",
       "integrity": "sha512-+IRvUm+huJn2KqfFW3yW/cjvRwJ8Q7FzYHoUNx5Fr0Lws0LxjMJG1uVB8HDpLwm7mg5XXH2M5MF+0jj5cM8BpQ==",
+      "dev": true,
       "requires": {
         "@opentelemetry/core": "1.19.0",
         "@opentelemetry/resources": "1.19.0",
@@ -7336,6 +7831,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.19.0.tgz",
       "integrity": "sha512-TCiEq/cUjM15RFqBRwWomTVbOqzndWL4ILa7ZCu0zbjU1/XY6AgHkgrgAc7vGP6TjRqH4Xryuglol8tcIfbBUQ==",
+      "dev": true,
       "requires": {
         "@opentelemetry/context-async-hooks": "1.19.0",
         "@opentelemetry/core": "1.19.0",
@@ -7349,6 +7845,7 @@
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
           "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -7358,7 +7855,8 @@
     "@opentelemetry/semantic-conventions": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.19.0.tgz",
-      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg=="
+      "integrity": "sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==",
+      "dev": true
     },
     "@opentelemetry/sql-common": {
       "version": "0.40.0",
@@ -8864,9 +9362,9 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
+      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.2",
@@ -9133,14 +9631,14 @@
       }
     },
     "joi": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
-      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+      "version": "17.11.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.1.tgz",
+      "integrity": "sha512-671acnrx+w96PCcQOzvm0VYQVwNL2PVgZmDRaFuSsx8sIUmGzYElPw5lU8F3Cr0jOuPs1oM56p7W2a1cdDOwcw==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.4",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -36,7 +36,7 @@
   },
   "main": "lib/index.js",
   "bin": {
-      "mockotlpserver": "lib/cli.js"
+    "mockotlpserver": "lib/cli.js"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.9.13",
@@ -47,10 +47,10 @@
     "safe-stable-stringify": "^2.4.3"
   },
   "devDependencies": {
-    "@opentelemetry/auto-instrumentations-node": "^0.40.2",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.46.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.46.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.46.0",
-    "@opentelemetry/sdk-node": "^0.46.0"
+    "@opentelemetry/auto-instrumentations-node": "^0.40.3",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.47.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.47.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.47.0",
+    "@opentelemetry/sdk-node": "^0.47.0"
   }
 }

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -32,9 +32,9 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@opentelemetry/instrumentation-http": "^0.46.0",
-    "@opentelemetry/resources": "^1.19.0",
-    "@opentelemetry/sdk-node": "^0.46.0",
+    "@opentelemetry/instrumentation-http": "^0.47.0",
+    "@opentelemetry/resources": "^1.20.0",
+    "@opentelemetry/sdk-node": "^0.47.0",
     "safe-stable-stringify": "^2.4.3"
   },
   "devDependencies": {

--- a/scripts/update-otel-deps.js
+++ b/scripts/update-otel-deps.js
@@ -14,7 +14,17 @@ const {globSync} = require('glob');
 const pj = require(path.resolve(__dirname, '../package.json'));
 
 function updateOTelDeps(workspace) {
-    const p = spawnSync('npm', ['outdated', '--json'], {
+    // Only consider packages in this workspace's "package.json".
+    // A bare `npm outdated` will also include linked to workspaces in the
+    // same monorepo.
+    const pkg = require(
+        path.resolve(__dirname, '..', workspace, 'package.json')
+    );
+    const otelDeps = Object.keys(pkg.dependencies)
+        .concat(Object.keys(pkg.devDependencies || {}))
+        .filter((d) => d.startsWith('@opentelemetry/'));
+
+    const p = spawnSync('npm', ['outdated', '--json'].concat(otelDeps), {
         cwd: workspace,
         encoding: 'utf8',
     });


### PR DESCRIPTION
Previously update-otel-deps would also add the deps from mockotlpserver
to the package.json for opentelemetry-node. That's because a bare
'npm outdated' would include deps from linked-to packages in the
same monorepo.
