### PR TITLE
refactor: SDK API play for discussion

### DIFF
--- a/packages/opentelemetry-node/examples/one-http-req.js
+++ b/packages/opentelemetry-node/examples/one-http-req.js
@@ -1,8 +1,9 @@
 // Start an HTTP server and make a single request to it.
 //
 // Usage:
-//      OTEL_SERVICE_NAME=one-http-req1 node -r ../start.js one-http-req.js
-//      OTEL_SERVICE_NAME=one-http-req2 node -r ./telemetry.js one-http-req.js
+//      OTEL_SERVICE_NAME=one-http-req node -r ../start.js one-http-req.js
+//      OTEL_SERVICE_NAME=one-http-req-tel1 node -r ./telemetry.js one-http-req.js
+//      OTEL_SERVICE_NAME=one-http-req-tel2 node -r ./telemetry2.js one-http-req.js
 
 const http = require('http');
 

--- a/packages/opentelemetry-node/examples/telemetry.js
+++ b/packages/opentelemetry-node/examples/telemetry.js
@@ -4,7 +4,9 @@
 
 const {ElasticNodeSDK} = require('../');
 
-const sdk = new ElasticNodeSDK();
+const sdk = new ElasticNodeSDK({
+    serviceName: process.env.TEL_SERVICE_NAME ?? undefined,
+});
 
 process.once('beforeExit', async () => {
     try {

--- a/packages/opentelemetry-node/examples/telemetry2.js
+++ b/packages/opentelemetry-node/examples/telemetry2.js
@@ -1,0 +1,26 @@
+// Setup OTel telemetry using `@elastic/opentelemetry-node`, using an
+// experimental alternative API where one uses the OTel NodeSDK directly and
+// uses Elastic's distro just for configuration helpers.
+
+const {getNodeSDKConfig} = require('../');
+const {NodeSDK} = require('@opentelemetry/sdk-node');
+
+// XXX I'm not sure where/what API would be appropriate to set diag to a luggite logger, if at all.
+
+const config = getNodeSDKConfig({
+    serviceName: process.env.TEL_SERVICE_NAME ?? undefined,
+});
+// XXX If this uses the *user's* selected NodeSDK version and the config schema changes
+//     then how can we know what form to use for `config`. This favours having our own
+//     internal subclass... or we need to be very strict about peerDep range. ??
+const sdk = new NodeSDK(config);
+
+process.once('beforeExit', async () => {
+    try {
+        await sdk.shutdown();
+    } catch (err) {
+        console.warn('warning: error shutting down OTel SDK', err);
+    }
+});
+
+sdk.start();

--- a/packages/opentelemetry-node/lib/config.js
+++ b/packages/opentelemetry-node/lib/config.js
@@ -1,0 +1,30 @@
+const {
+    envDetectorSync,
+    hostDetectorSync,
+    processDetectorSync,
+} = require('@opentelemetry/resources');
+const {HttpInstrumentation} = require('@opentelemetry/instrumentation-http');
+
+function getNodeSDKConfig(opts) {
+    const defaultConfig = {
+        resourceDetectors: [
+            envDetectorSync,
+            processDetectorSync,
+            // hostDetectorSync is not currently in the OTel default, but may be added
+            hostDetectorSync,
+            // TODO cloud/container detectors by default
+        ],
+        // TODO metrics
+        // TODO log exporter? Optionally. Compare to apm-agent-java opts.
+        // logRecordProcessor: new logs.SimpleLogRecordProcessor(new logs.ConsoleLogRecordExporter()),
+        instrumentations: [
+            // TODO All the instrumentations. Perf. Config support. Custom given instrs.
+            new HttpInstrumentation(),
+        ],
+    };
+    const config = Object.assign(defaultConfig, opts);
+    return config;
+}
+module.exports = {
+    getNodeSDKConfig,
+};

--- a/packages/opentelemetry-node/lib/index.js
+++ b/packages/opentelemetry-node/lib/index.js
@@ -1,5 +1,10 @@
+const {getNodeSDKConfig} = require('./config');
 const {ElasticNodeSDK} = require('./sdk');
 
+// TODO: if we go the "provide SDK subclass" route, then this should reexport
+//       things for @otel/sdk-node (like 'api', 'core', etc.)
+
 module.exports = {
+    getNodeSDKConfig,
     ElasticNodeSDK,
 };

--- a/packages/opentelemetry-node/lib/sdk.js
+++ b/packages/opentelemetry-node/lib/sdk.js
@@ -30,9 +30,13 @@ function luggiteLevelFromOtelLogLevel(otelLogLevel) {
     return luggiteLevel;
 }
 
-class ElasticNodeSDK {
-    constructor() {
-        this._setupLogger();
+/**
+ * @param {Partial<import('@opentelemetry/sdk-node').NodeSDKConfiguration>} opts
+ */
+class ElasticNodeSDK extends NodeSDK {
+    constructor(opts = {}) {
+        const log = createLogger();
+        log.trace('ElasticNodeSDK opts:', opts);
 
         if (!('OTEL_TRACES_EXPORTER' in process.env)) {
             // Ensure this envvar is set to avoid a diag.warn() in NodeSDK.
@@ -43,7 +47,7 @@ class ElasticNodeSDK {
 
         // - NodeSDK defaults to `TracerProviderWithEnvExporters` if neither
         //   `spanProcessor` nor `traceExporter` are passed in.
-        this._otelSdk = new NodeSDK({
+        const defaultConfig = {
             resourceDetectors: [
                 envDetectorSync,
                 processDetectorSync,
@@ -58,51 +62,57 @@ class ElasticNodeSDK {
                 // TODO All the instrumentations. Perf. Config support. Custom given instrs.
                 new HttpInstrumentation(),
             ],
-        });
-    }
+        };
 
-    start() {
-        return this._otelSdk.start();
-    }
-
-    shutdown() {
-        return this._otelSdk.shutdown();
-    }
-
-    /**
-     * Setup a `this._log` using the level from OTEL_LOG_LEVEL, default 'info'.
-     * Also set this logger to handle `api.diag.*()` log methods.
-     */
-    _setupLogger() {
-        let level;
-        let diagLevel;
-        if (process.env.OTEL_LOG_LEVEL) {
-            const otelLogLevel = process.env.OTEL_LOG_LEVEL.toUpperCase();
-            level = luggiteLevelFromOtelLogLevel(otelLogLevel);
-            diagLevel = otelLogLevel;
-            // Make sure NodeSDK doesn't see this envvar and overwrite our diag logger.
-            delete process.env.OTEL_LOG_LEVEL;
-        }
-        if (!level) {
-            level = 'info'; // default level
-            diagLevel = 'INFO';
-        }
-
-        const log = luggite.createLogger({name: 'elastic-otel-node', level});
-        // TODO: when luggite supports .child, add a module/component attr for diag log output
-        api.diag.setLogger(
-            {
-                error: log.error.bind(log),
-                warn: log.warn.bind(log),
-                info: log.info.bind(log),
-                debug: log.debug.bind(log),
-                verbose: log.trace.bind(log),
-            },
-            api.DiagLogLevel[diagLevel]
-        );
+        const configuration = Object.assign(defaultConfig, opts);
+        super(configuration);
 
         this._log = log;
     }
+
+    start() {
+        // TODO: make this preable useful, or drop it
+        this._log.info(
+            {premable: true},
+            'starting Elastic OpenTelemetry Node.js SDK distro'
+        );
+        super.start();
+    }
+}
+
+/**
+ * Create a logger the level from OTEL_LOG_LEVEL, default 'info'.
+ * Also set this logger to handle `api.diag.*()` log methods.
+ */
+function createLogger() {
+    let level;
+    let diagLevel;
+    if (process.env.OTEL_LOG_LEVEL) {
+        const otelLogLevel = process.env.OTEL_LOG_LEVEL.toUpperCase();
+        level = luggiteLevelFromOtelLogLevel(otelLogLevel);
+        diagLevel = otelLogLevel;
+        // Make sure NodeSDK doesn't see this envvar and overwrite our diag logger.
+        delete process.env.OTEL_LOG_LEVEL;
+    }
+    if (!level) {
+        level = 'info'; // default level
+        diagLevel = 'INFO';
+    }
+
+    const log = luggite.createLogger({name: 'elastic-otel-node', level});
+    // TODO: when luggite supports .child, add a module/component attr for diag log output
+    api.diag.setLogger(
+        {
+            error: log.error.bind(log),
+            warn: log.warn.bind(log),
+            info: log.info.bind(log),
+            debug: log.debug.bind(log),
+            verbose: log.trace.bind(log),
+        },
+        api.DiagLogLevel[diagLevel]
+    );
+
+    return log;
 }
 
 module.exports = {


### PR DESCRIPTION
@david-luna Here is a PR with a few changes exploring the "Hot take" discussion (https://github.com/elastic/apm-nodejs-dev/issues/9#issuecomment-1894357223) for the SDK API to provide. "to be NodeSDK, or not ..."

First, I haven't changed the "start.js convenience" use case:

```
cd examples
OTEL_SERVICE_NAME=usage0 node -r ../start.js one-http-req.js
```

* * *

Next, is the "configure and start the SDK in code" use case, still using our `ElasticNodeSDK`:

```
cd examples
OTEL_SERVICE_NAME=usage1 node -r ./telemetry.js one-http-req.js
```

See [telemetry.js](https://github.com/elastic/elastic-otel-node/blob/trentm/sdk-api-play/packages/opentelemetry-node/examples/telemetry.js).

* * *

Then, as an alternative to lib/sdk.js, I added [lib/config.js](https://github.com/elastic/elastic-otel-node/blob/trentm/sdk-api-play/packages/opentelemetry-node/lib/config.js), which is used from [examples/telemetry2.js](https://github.com/elastic/elastic-otel-node/blob/trentm/sdk-api-play/packages/opentelemetry-node/examples/telemetry2.js#L10-L16):

```
cd examples
OTEL_SERVICE_NAME=usage2 node -r ./telemetry2.js one-http-req.js
```

This is the "just provide special-sauce methods" option.  There are a couple "XXX"s in "telemetry2.js" discussing potential issues. I'll add review comments for each.