### PR TITLE
chore: add types into test utils file

### DIFF
--- a/packages/opentelemetry-node/test/OTEL_LOG_LEVEL.test.js
+++ b/packages/opentelemetry-node/test/OTEL_LOG_LEVEL.test.js
@@ -3,6 +3,7 @@
 const {test} = require('tape');
 const {runTestFixtures} = require('./testutils');
 
+/** @type {import('./testutils').TestFixture[]} */
 const testFixtures = [
     {
         name: 'diag default',

--- a/packages/opentelemetry-node/test/instr-express.test.js
+++ b/packages/opentelemetry-node/test/instr-express.test.js
@@ -3,6 +3,7 @@
 const test = require('tape');
 const {runTestFixtures, findObjInArray} = require('./testutils');
 
+/** @type {import('./testutils').TestFixture[]} */
 const testFixtures = [
     {
         name: 'use-express',

--- a/packages/opentelemetry-node/test/instr-http.test.js
+++ b/packages/opentelemetry-node/test/instr-http.test.js
@@ -3,6 +3,7 @@
 const test = require('tape');
 const {runTestFixtures} = require('./testutils');
 
+/** @type {import('./testutils').TestFixture[]} */
 const testFixtures = [
     {
         name: 'http.get',


### PR DESCRIPTION
Add types into test utils, specially in `runTestFixtures` function. With these types we will get the proper autocompletion in callbacks such `checkResult` & `checkTelemetry`.