### PR TITLE
chore: enable and config dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "elastic/apm-agent-node-js"
+    groups:
+      otel:
+        patterns:
+        - "@opentelemetry/*"
+      eslint:
+        dependency-type: "development"
+        patterns:
+        - "eslint*"

--- a/scripts/update-otel-deps.js
+++ b/scripts/update-otel-deps.js
@@ -20,7 +20,7 @@ function updateOTelDeps(workspace) {
     const pkg = require(
         path.resolve(__dirname, '..', workspace, 'package.json')
     );
-    const otelDeps = Object.keys(pkg.dependencies)
+    const otelDeps = Object.keys(pkg.dependencies || {})
         .concat(Object.keys(pkg.devDependencies || {}))
         .filter((d) => d.startsWith('@opentelemetry/'));
 


### PR DESCRIPTION
Partly this is a test to see if the `@opentelemetry/*` group works for dependabot updates.
The alternative to that group is to use `scripts/update-otel-deps.js`.

Closes: https://github.com/elastic/elastic-otel-node/issues/48