### PR TITLE
chore: stop calling deprecated grpcServer.start

### DIFF
--- a/packages/mockotlpserver/lib/grpc.js
+++ b/packages/mockotlpserver/lib/grpc.js
@@ -94,7 +94,6 @@ class GrpcService extends Service {
                         reject(err);
                     } else {
                         this._port = boundPort;
-                        this._grpcServer.start();
                         resolve();
                     }
                 }


### PR DESCRIPTION
As of @grpc/grpc-js 1.10.0 '.start()' is deprecated and a no-op.

Refs: https://github.com/elastic/elastic-otel-node/pull/60
Refs: https://github.com/grpc/proposal/blob/master/L107-node-noop-start.md

* * *

Before this change mockotlpserver would show a deprecation warning on startup:

```
% node --trace-deprecation lib/cli.js
{"name":"mockotlpserver","level":30,"msg":"OTLP/HTTP listening at http://127.0.0.1:4318/","time":"2024-02-12T17:33:35.493Z"}
{"name":"mockotlpserver","level":30,"msg":"OTLP/HTTP listening at http://localhost:4317/","time":"2024-02-12T17:33:35.500Z"}
(node:72369) DeprecationWarning: Calling start() is no longer necessary. It can be safely omitted.
    at /Users/trentm/el/elastic-otel-node2/packages/mockotlpserver/lib/grpc.js:97:42
    at /Users/trentm/el/elastic-otel-node2/node_modules/@grpc/grpc-js/build/src/server.js:567:25
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
{"name":"mockotlpserver","level":30,"msg":"UI listening at http://127.0.0.1:8080/","time":"2024-02-12T17:33:35.502Z"}
```