### PR TITLE
chore: remove debugging console output

### DIFF
--- a/packages/opentelemetry-node/lib/.eslintrc.json
+++ b/packages/opentelemetry-node/lib/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "warn"
+  }
+}

--- a/packages/opentelemetry-node/lib/metrics/host.js
+++ b/packages/opentelemetry-node/lib/metrics/host.js
@@ -172,9 +172,6 @@ class SystemCpuUtilizationAggregator {
         accumulationByAttributes,
         endTime
     ) {
-        console.log('toMetricdata');
-        console.dir(accumulationByAttributes, {depth: 5});
-
         // We cannot sum up the utilization of all the states since `os.cpus()` is
         // not returning all of the possible states but limited to: user, nice, sys, idle, irq
         // https://nodejs.org/api/all.html#all_os_oscpus


### PR DESCRIPTION
This also adds a rule to *warn* about doing so in the distro lib files.
I don't want to error on these because it I think it would get in the
way of PR dev. If a console.log slips in, then that's not so bad.
