### PR TITLE
chore(deps): update deps matching "@opentelemetry/*"

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -6,7 +6,7 @@
   "scripts": {},
   "devDependencies": {
     "@elastic/opentelemetry-node": "*",
-    "@opentelemetry/instrumentation-bunyan": "^0.35.0",
+    "@opentelemetry/instrumentation-bunyan": "^0.36.0",
     "bunyan": "^1.8.15",
     "express": "^4.18.3"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@elastic/opentelemetry-node": "*",
-        "@opentelemetry/instrumentation-bunyan": "^0.35.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.36.0",
         "bunyan": "^1.8.15",
         "express": "^4.18.3"
       }
@@ -380,15 +380,17 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.7.0",
-      "license": "Apache-2.0",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
+      "integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -397,40 +399,43 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.22.0.tgz",
+      "integrity": "sha512-Nfdxyg8YtWqVWkyrCukkundAjPhUXi93JtVQmqDT1mZRVKqA7e2r7eJCrI+F651XUBMp0hsOJSGiFk3QSpaIJw==",
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+      "integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.49.1.tgz",
+      "integrity": "sha512-WTCUzGkw6XUBA7SLEgkpdhcaqz04yoOFqO442bXibo4nyXTF2flvgHs6s4pNGLGrtA3KLNO5R30Qm6ivkj0a1Q==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -440,14 +445,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.49.1.tgz",
+      "integrity": "sha512-t/sWYqfcwn81SvYHIyYJDlJD2CjFz3/h2t4j+XCtdoHAfu+WVJQmwLsGYJPlCDp3UXQfFpMJMWvLlvtD2SL+rg==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -457,16 +463,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.49.1.tgz",
+      "integrity": "sha512-xKI6aCRY+STxbF7PA+6YNNYWFf6IS065rZZeqlqvqQsp0HaFUqpPEzMJn0OmQMGuy40o7wWtmZ9/bSu4jlhfYw==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -476,15 +483,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.49.1.tgz",
+      "integrity": "sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -494,14 +502,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.49.1.tgz",
+      "integrity": "sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -511,15 +520,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.49.1.tgz",
+      "integrity": "sha512-n8ON/c9pdMyYAfSFWKkgsPwjYoxnki+6Olzo+klKfW7KqLWoyEkryNkbcMIYnGGNXwdkMIrjoaP0VxXB26Oxcg==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -529,13 +539,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.22.0.tgz",
+      "integrity": "sha512-XcFs6rGvcTz0qW5uY7JZDYD0yNEXdekXAb6sFtnZgY/cHY6BQ09HMzOjv9SX+iaXplRDcHr1Gta7VQKM1XXM6g==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -559,9 +570,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.49.1.tgz",
+      "integrity": "sha512-0DLtWtaIppuNNRRllSD4bjU8ZIiLp1cDXvJEbp752/Zf+y3gaLNaoGRGIlX4UHhcsrmtL+P2qxi3Hodi8VuKiQ==",
       "dependencies": {
+        "@opentelemetry/api-logs": "0.49.1",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
@@ -576,12 +589,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.36.0.tgz",
+      "integrity": "sha512-sHD5BSiqSrgWow7VmugEFzV8vGdsz5m+w1v9tK6YwRzuAD7vbo57chluq+UBzIqStoCH+0yOzRzSALH7hrfffg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.48.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/api-logs": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@types/bunyan": "1.8.9"
       },
       "engines": {
@@ -592,11 +606,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.35.0",
-      "license": "Apache-2.0",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.36.1.tgz",
+      "integrity": "sha512-ltIE4kIMa+83QjW/p7oe7XCESF29w3FQ9/T1VgShdX7fzm56K2a0xfEX1vF8lnHRGERYxIWX9D086C6gJOjVGA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -607,12 +622,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.49.1.tgz",
+      "integrity": "sha512-Yib5zrW2s0V8wTeUK/B3ZtpyP4ldgXj9L3Ws/axXrW1dW0/mEFKifK50MxMQK9g5NNJQS9dWH7rvcEGZdWdQDA==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.1",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -623,10 +639,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -636,12 +653,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -652,11 +670,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -667,154 +686,164 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
+      "integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.22.0.tgz",
+      "integrity": "sha512-qBItJm9ygg/jCB5rmivyGz1qmKZPsL/sX715JqPMFgq++Idm0x+N9sLQvWFHFt2+ZINnCSojw7FVBgFW6izcXA==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.22.0.tgz",
+      "integrity": "sha512-pMLgst3QIwrUfepraH5WG7xfpJ8J3CrPKrtINK0t7kBkuu96rn+HDYQ8kt3+0FXvrZI8YJE77MCQwnJWXIrgpA==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
+      "integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.8.0",
+        "@opentelemetry/api": ">=1.4.0 <1.9.0",
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
+      "integrity": "sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.48.0",
-      "license": "Apache-2.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.49.1.tgz",
+      "integrity": "sha512-feBIT85ndiSHXsQ2gfGpXC/sNeX4GCHLksC4A9s/bfpUbbgbCSl0RvzZlmEpCHarNrkZMwFRi4H0xFfgvJEjrg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
+      "integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.22.0.tgz",
+      "integrity": "sha512-gTGquNz7ue8uMeiWPwp3CU321OstQ84r7PCDtOaCicjbJxzvO8RZMlEC4geOipTeiF88kss5n6w+//A0MhP1lQ==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/propagator-jaeger": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/propagator-jaeger": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.21.0",
-      "license": "Apache-2.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
       "engines": {
         "node": ">=14"
       }
@@ -5589,14 +5618,14 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/exporter-logs-otlp-proto": "^0.48.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.48.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "^0.49.1",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.49.1",
         "@opentelemetry/host-metrics": "^0.35.0",
-        "@opentelemetry/instrumentation-express": "^0.35.0",
-        "@opentelemetry/instrumentation-http": "^0.48.0",
+        "@opentelemetry/instrumentation-express": "^0.36.1",
+        "@opentelemetry/instrumentation-http": "^0.49.1",
         "@opentelemetry/resources": "^1.20.0",
-        "@opentelemetry/sdk-logs": "^0.48.0",
-        "@opentelemetry/sdk-node": "^0.48.0",
+        "@opentelemetry/sdk-logs": "^0.49.1",
+        "@opentelemetry/sdk-node": "^0.49.1",
         "safe-stable-stringify": "^2.4.3"
       },
       "devDependencies": {
@@ -5642,14 +5671,14 @@
       "requires": {
         "@elastic/mockotlpserver": "*",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "^0.48.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.48.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "^0.49.1",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.49.1",
         "@opentelemetry/host-metrics": "^0.35.0",
-        "@opentelemetry/instrumentation-express": "^0.35.0",
-        "@opentelemetry/instrumentation-http": "^0.48.0",
+        "@opentelemetry/instrumentation-express": "^0.36.1",
+        "@opentelemetry/instrumentation-http": "^0.49.1",
         "@opentelemetry/resources": "^1.20.0",
-        "@opentelemetry/sdk-logs": "^0.48.0",
-        "@opentelemetry/sdk-node": "^0.48.0",
+        "@opentelemetry/sdk-logs": "^0.49.1",
+        "@opentelemetry/sdk-node": "^0.49.1",
         "@types/tape": "^5.6.4",
         "express": "^4.18.3",
         "module-details-from-path": "^1.0.3",
@@ -5866,98 +5895,120 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.7.0"
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w=="
     },
     "@opentelemetry/api-logs": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
+      "integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
       "requires": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.21.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.22.0.tgz",
+      "integrity": "sha512-Nfdxyg8YtWqVWkyrCukkundAjPhUXi93JtVQmqDT1mZRVKqA7e2r7eJCrI+F651XUBMp0hsOJSGiFk3QSpaIJw==",
       "requires": {}
     },
     "@opentelemetry/core": {
-      "version": "1.21.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+      "integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/semantic-conventions": "1.22.0"
       }
     },
     "@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.49.1.tgz",
+      "integrity": "sha512-WTCUzGkw6XUBA7SLEgkpdhcaqz04yoOFqO442bXibo4nyXTF2flvgHs6s4pNGLGrtA3KLNO5R30Qm6ivkj0a1Q==",
       "requires": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       }
     },
     "@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.49.1.tgz",
+      "integrity": "sha512-t/sWYqfcwn81SvYHIyYJDlJD2CjFz3/h2t4j+XCtdoHAfu+WVJQmwLsGYJPlCDp3UXQfFpMJMWvLlvtD2SL+rg==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       }
     },
     "@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.49.1.tgz",
+      "integrity": "sha512-xKI6aCRY+STxbF7PA+6YNNYWFf6IS065rZZeqlqvqQsp0HaFUqpPEzMJn0OmQMGuy40o7wWtmZ9/bSu4jlhfYw==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.49.1.tgz",
+      "integrity": "sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.49.1.tgz",
+      "integrity": "sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.49.1.tgz",
+      "integrity": "sha512-n8ON/c9pdMyYAfSFWKkgsPwjYoxnki+6Olzo+klKfW7KqLWoyEkryNkbcMIYnGGNXwdkMIrjoaP0VxXB26Oxcg==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-transformer": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       }
     },
     "@opentelemetry/exporter-zipkin": {
-      "version": "1.21.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.22.0.tgz",
+      "integrity": "sha512-XcFs6rGvcTz0qW5uY7JZDYD0yNEXdekXAb6sFtnZgY/cHY6BQ09HMzOjv9SX+iaXplRDcHr1Gta7VQKM1XXM6g==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       }
     },
     "@opentelemetry/host-metrics": {
@@ -5968,8 +6019,11 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.49.1.tgz",
+      "integrity": "sha512-0DLtWtaIppuNNRRllSD4bjU8ZIiLp1cDXvJEbp752/Zf+y3gaLNaoGRGIlX4UHhcsrmtL+P2qxi3Hodi8VuKiQ==",
       "requires": {
+        "@opentelemetry/api-logs": "0.49.1",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
@@ -5978,138 +6032,170 @@
       }
     },
     "@opentelemetry/instrumentation-bunyan": {
-      "version": "0.35.0",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.36.0.tgz",
+      "integrity": "sha512-sHD5BSiqSrgWow7VmugEFzV8vGdsz5m+w1v9tK6YwRzuAD7vbo57chluq+UBzIqStoCH+0yOzRzSALH7hrfffg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/api-logs": "^0.48.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/api-logs": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@types/bunyan": "1.8.9"
       }
     },
     "@opentelemetry/instrumentation-express": {
-      "version": "0.35.0",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.36.1.tgz",
+      "integrity": "sha512-ltIE4kIMa+83QjW/p7oe7XCESF29w3FQ9/T1VgShdX7fzm56K2a0xfEX1vF8lnHRGERYxIWX9D086C6gJOjVGA==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.49.1.tgz",
+      "integrity": "sha512-Yib5zrW2s0V8wTeUK/B3ZtpyP4ldgXj9L3Ws/axXrW1dW0/mEFKifK50MxMQK9g5NNJQS9dWH7rvcEGZdWdQDA==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.1",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "semver": "^7.5.2"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
       "requires": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
         "protobufjs": "^7.2.3"
       }
     },
     "@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.49.1.tgz",
+      "integrity": "sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.1",
         "protobufjs": "^7.2.3"
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
+      "integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
       "requires": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.21.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.22.0.tgz",
+      "integrity": "sha512-qBItJm9ygg/jCB5rmivyGz1qmKZPsL/sX715JqPMFgq++Idm0x+N9sLQvWFHFt2+ZINnCSojw7FVBgFW6izcXA==",
       "requires": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.21.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.22.0.tgz",
+      "integrity": "sha512-pMLgst3QIwrUfepraH5WG7xfpJ8J3CrPKrtINK0t7kBkuu96rn+HDYQ8kt3+0FXvrZI8YJE77MCQwnJWXIrgpA==",
       "requires": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.21.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       }
     },
     "@opentelemetry/sdk-logs": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
+      "integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.21.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
+      "integrity": "sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
         "lodash.merge": "^4.6.2"
       }
     },
     "@opentelemetry/sdk-node": {
-      "version": "0.48.0",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.49.1.tgz",
+      "integrity": "sha512-feBIT85ndiSHXsQ2gfGpXC/sNeX4GCHLksC4A9s/bfpUbbgbCSl0RvzZlmEpCHarNrkZMwFRi4H0xFfgvJEjrg==",
       "requires": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.21.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
+      "integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
       "requires": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.21.0",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.22.0.tgz",
+      "integrity": "sha512-gTGquNz7ue8uMeiWPwp3CU321OstQ84r7PCDtOaCicjbJxzvO8RZMlEC4geOipTeiF88kss5n6w+//A0MhP1lQ==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/propagator-jaeger": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/propagator-jaeger": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "semver": "^7.5.2"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.21.0"
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -6709,7 +6795,7 @@
       "version": "file:examples",
       "requires": {
         "@elastic/opentelemetry-node": "*",
-        "@opentelemetry/instrumentation-bunyan": "^0.35.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.36.0",
         "bunyan": "^1.8.15",
         "express": "^4.18.3"
       }

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -34,14 +34,14 @@
   "main": "lib/index.js",
   "types": "lib/types.d.ts",
   "dependencies": {
-    "@opentelemetry/exporter-logs-otlp-proto": "^0.48.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.48.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.49.1",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.49.1",
     "@opentelemetry/host-metrics": "^0.35.0",
-    "@opentelemetry/instrumentation-express": "^0.35.0",
-    "@opentelemetry/instrumentation-http": "^0.48.0",
+    "@opentelemetry/instrumentation-express": "^0.36.1",
+    "@opentelemetry/instrumentation-http": "^0.49.1",
     "@opentelemetry/resources": "^1.20.0",
-    "@opentelemetry/sdk-logs": "^0.48.0",
-    "@opentelemetry/sdk-node": "^0.48.0",
+    "@opentelemetry/sdk-logs": "^0.49.1",
+    "@opentelemetry/sdk-node": "^0.49.1",
     "safe-stable-stringify": "^2.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
    0.35.0 -> 0.36.0 @opentelemetry/instrumentation-bunyan (range-bump)
    0.35.0 -> 0.36.1 @opentelemetry/instrumentation-express (range-bump)
    0.48.0 -> 0.49.1 @opentelemetry/exporter-logs-otlp-proto (range-bump)
    0.48.0 -> 0.49.1 @opentelemetry/exporter-metrics-otlp-proto (range-bump)
    0.48.0 -> 0.49.1 @opentelemetry/instrumentation-http (range-bump)
    0.48.0 -> 0.49.1 @opentelemetry/sdk-logs (range-bump)
    0.48.0 -> 0.49.1 @opentelemetry/sdk-node (range-bump)
    1.7.0 -> 1.8.0 @opentelemetry/api
    1.21.0 -> 1.22.0 @opentelemetry/core
    1.21.0 -> 1.22.0 @opentelemetry/resources
