### PR TITLE
feat(mockotlpserver): CLI --hostname option

### DIFF
--- a/packages/mockotlpserver/lib/cli.js
+++ b/packages/mockotlpserver/lib/cli.js
@@ -9,7 +9,7 @@ const {JSONPrinter, InspectPrinter} = require('./printers');
 const {TraceWaterfallPrinter} = require('./waterfall');
 const {MetricsSummaryPrinter} = require('./metrics-summary');
 const {LogsSummaryPrinter} = require('./logs-summary');
-const {MockOtlpServer} = require('./mockotlpserver');
+const {DEFAULT_HOSTNAME, MockOtlpServer} = require('./mockotlpserver');
 
 const PRINTER_NAMES = [
     'trace-inspect',
@@ -73,6 +73,11 @@ const OPTIONS = [
         )}".`,
         default: ['inspect', 'summary'],
     },
+    {
+        names: ['hostname'],
+        type: 'string',
+        help: `The hostname on which servers should listen, by default this is "${DEFAULT_HOSTNAME}".`,
+    },
 ];
 
 async function main() {
@@ -100,6 +105,9 @@ async function main() {
     const otlpServer = new MockOtlpServer({
         log,
         services: ['http', 'grpc', 'ui'],
+        grpcHostname: opts.hostname || DEFAULT_HOSTNAME,
+        httpHostname: opts.hostname || DEFAULT_HOSTNAME,
+        uiHostname: opts.hostname || DEFAULT_HOSTNAME,
     });
     await otlpServer.start();
 

--- a/packages/mockotlpserver/lib/mockotlpserver.js
+++ b/packages/mockotlpserver/lib/mockotlpserver.js
@@ -140,5 +140,6 @@ class MockOtlpServer {
 }
 
 module.exports = {
+    DEFAULT_HOSTNAME,
     MockOtlpServer,
 };


### PR DESCRIPTION
This allows passing in the hostname that will be used for
the HTTP/gRPC servers to listen on. I added this in case it
is helpful to avoid the 'localhost' default that can be
ambiguously IPv4 or IPv6 depending on the node version. I
don't expect the option to be frequently used.
