### PR TITLE
test: skip too-frequently flaky system.cpu.utilization range test

### DIFF
--- a/packages/opentelemetry-node/test/host-metrics.test.js
+++ b/packages/opentelemetry-node/test/host-metrics.test.js
@@ -44,20 +44,21 @@ const testFixtures = [
                     metric.gauge,
                     'data points are present in system.cpu.utilization metric'
                 );
-                const allInRange = metric.gauge?.dataPoints.every(
-                    (dp) => 0 <= dp.asDouble && dp.asDouble <= 1
-                );
-                t.ok(
-                    allInRange,
-                    '"system.cpu.utilization" data points are in the range [0,1]'
-                );
-                if (!allInRange) {
-                    // Note: extra output to debug flaky test (https://github.com/elastic/elastic-otel-node/issues/73).
-                    t.comment(
-                        'cpuUtilizationMetrics: ' +
-                            JSON.stringify(cpuUtilizationMetrics)
-                    );
-                }
+                // Note: Skip this too-frequently flaky test for now. See https://github.com/elastic/elastic-otel-node/issues/73
+                // const allInRange = metric.gauge?.dataPoints.every(
+                //     (dp) => 0 <= dp.asDouble && dp.asDouble <= 1
+                // );
+                // t.ok(
+                //     allInRange,
+                //     '"system.cpu.utilization" data points are in the range [0,1]'
+                // );
+                // if (!allInRange) {
+                //     // Note: extra output to debug flaky test (https://github.com/elastic/elastic-otel-node/issues/73).
+                //     t.comment(
+                //         'cpuUtilizationMetrics: ' +
+                //             JSON.stringify(cpuUtilizationMetrics)
+                //     );
+                // }
                 t.ok(
                     metric.gauge?.dataPoints.filter(
                         (dp) =>


### PR DESCRIPTION
This test is failing almost every time on macos, and periodically
in CI. Skip it for now as it is disruptive to dev.

Refs: #73
