### PR TITLE
test: fix some flakiness issues with OTLP metrics normalization and the host-metrics test

### DIFF
--- a/packages/opentelemetry-node/test/fixtures/use-host-metrics.js
+++ b/packages/opentelemetry-node/test/fixtures/use-host-metrics.js
@@ -1,16 +1,22 @@
+// Usage: node -r ../../start.js use-host-metrics.js
+
 const {createHash} = require('crypto');
 
-const exportInterval = process.env.ETEL_METRICS_INTERVAL_MS;
-const exportTime = Date.now() + exportInterval * 1.5;
-
-// Do some operations to get some CPU usage
-const timerId = setInterval(() => {
-    if (exportTime < Date.now()) {
-        clearInterval(timerId);
-        return;
-    }
-
+// Do some work to get some CPU usage for more interesting HostMetrics values.
+let lastProgressTime = Date.now();
+const workInterval = setInterval(() => {
     const hash = createHash('sha256');
     hash.update(new Array(100).fill(Math.random()).join(','));
-    console.log(hash.digest('hex'));
+    if (Date.now() - lastProgressTime > 500) {
+        console.log('.');
+        lastProgressTime = Date.now();
+    }
 }, 10);
+
+// Finish after 1.5x the metrics export interval, to be sure that some
+// metrics have been reported for testing.
+const exportInterval = process.env.ETEL_METRICS_INTERVAL_MS || 30000;
+setTimeout(() => {
+    console.log('finishing');
+    clearInterval(workInterval);
+}, exportInterval * 1.5);


### PR DESCRIPTION
- Avoid using a 100ms metrics interval for a faster host-metrics test
  because that results in an occasional PeriodicExportingMetricReader
  timeout, that (I believe) leads to OTLP Metrics requests with empty
  'scopeMetrics':
    ```
    ExportMetricsServiceRequest {
      resourceMetrics: [
        ResourceMetrics {
          scopeMetrics: [],
          resource: Resource { ... }
        }
      ]
    }
    ```
  which leads to 'normalizeMetrics' creating a normalized metrics
  object without the 'scopeMetrics' attribute (I'm not sure if
  this is a bug, but if so, not sure where to fix it).

  Similar case with this:
    ```
    Metric {
      name: 'system.cpu.utilization',
      description: 'Cpu usage time 0-1',
      unit: '',
      gauge: Gauge { dataPoints: [] }
    ```
  being normalized to:
    ```
    {
      "name": "system.cpu.utilization",
      "description": "Cpu usage time 0-1",
      "unit": "",
      "gauge": {},
    ```
  which surprises code expecting `metric?.gauge.dataPoints` to work.

- Also add some defensive handling in TestCollector.metrics getter
  and in host-metrics.test.js to avoid crashing on these odd
  normalized metrics with empty data / missing properties.

- Also fix a bug in `runTestFixtures()` handling of `verbose: true`
  that couldn't `quoteArg` and env value that wasn't a string.

- Also refactor "use-host-metrics.js". When run without
  ETEL_METRICS_INTERVAL_MS set, it would never terminate.

Fixes: https://github.com/elastic/elastic-otel-node/issues/97
