### PR TITLE
version 0.1.1, release fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'v18.20.2'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci --ignore-scripts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7807,7 +7807,7 @@
     },
     "packages/opentelemetry-node": {
       "name": "@elastic/opentelemetry-node",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/exporter-logs-otlp-proto": "^0.51.0",

--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 (nothing yet)
 
+## v0.1.1
+
+- Trim files included in published npm package.
+
 ## v0.1.0
 
 The first release of the Elastic OpenTelemetry Node.js distribution.

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "commonjs",
   "description": "Elastic OpenTelemetry distribution for Node.js",
   "publishConfig": {
@@ -26,6 +26,18 @@
   "engines": {
     "node": ">=14"
   },
+  "files": [
+    "lib",
+    "types",
+    "CHANGELOG.md",
+    "LICENSE",
+    "NOTICE.md",
+    "README.md",
+    "hook.mjs",
+    "import.mjs",
+    "package.json",
+    "require.js"
+  ],
   "scripts": {
     "example": "cd ../../examples && node -r @elastic/opentelemetry-node simple-http-request.js",
     "lint": "npm run lint:eslint && npm run lint:types && npm run lint:deps && npm run lint:license-files && npm run lint:changelog",


### PR DESCRIPTION
- limit files included in the published package (no need to publish docs and tests)
- fix release.yml workflow to setup npm login
