### PR TITLE
release 0.1.2; apply 'npm pkg fix' changes required by provenance generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7807,7 +7807,7 @@
     },
     "packages/opentelemetry-node": {
       "name": "@elastic/opentelemetry-node",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/exporter-logs-otlp-proto": "^0.51.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "elastic-otel-node",
+  "version": "0.1.0",
   "workspaces": [
     "packages/*",
     "examples"

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/elastic/elastic-otel-node.git",
+    "url": "git+https://github.com/elastic/elastic-otel-node.git",
     "directory": "packages/mockotlpserver"
   },
   "keywords": [

--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 (nothing yet)
 
+## v0.1.2
+
+- Correct "repository.url" setting in package.json, required for npm provenance
+  generation.
+
 ## v0.1.1
 
 - Trim files included in published npm package.

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "commonjs",
   "description": "Elastic OpenTelemetry distribution for Node.js",
   "publishConfig": {
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/elastic/elastic-otel-java.git",
+    "url": "git+https://github.com/elastic/elastic-otel-java.git",
     "directory": "packages/opentelemetry-node"
   },
   "keywords": [


### PR DESCRIPTION
This is a follow-on from https://github.com/elastic/elastic-otel-node/pull/159

The release attempt failed to 'npm publish' in https://github.com/elastic/elastic-otel-node/actions/runs/8899712600/job/24439813707

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository.url" was normalized to "git+https://github.com/elastic/elastic-otel-java.git"
npm notice 
npm notice 📦  @elastic/opentelemetry-node@0.1.1
...
npm notice total files:   27                                      
npm notice 
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=89932488
npm ERR! code E422
npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/@elastic%2fopentelemetry-node - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/elastic/elastic-otel-java.git", expected to match "https://github.com/elastic/elastic-otel-node" from provenance
npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2024-04-30T18_24_32_156Z-debug-0.log
```

... because provenance generation is apparently very picky about package.json changes, and the automatic 'npm pkg fix' during 'npm publish' broke that.