### PR TITLE
fix(mockotlpserver): fix logs-summary crash on a LogRecord with no attributes

### DIFF
--- a/packages/mockotlpserver/lib/logs-summary.js
+++ b/packages/mockotlpserver/lib/logs-summary.js
@@ -91,7 +91,10 @@ class LogsSummaryPrinter extends Printer {
                             rec.severityNumber
                         } (${meta}): ${stylizeWithColor(rec.body, 'cyan')}`
                     );
-                    if (Object.keys(rec.attributes).length > 0) {
+                    if (
+                        rec.attributes &&
+                        Object.keys(rec.attributes).length > 0
+                    ) {
                         let attrSummary = util
                             .inspect(rec.attributes, {
                                 depth: 10,


### PR DESCRIPTION
The normalized LogRecord, for better or worse, elides the 'attributes'
property if there are no attributes.

* * *

An example hitting this is with this:

```js
const pino = require('pino')
const transport = pino.transport({
  target: 'pino-opentelemetry-transport'
})

const logger = pino(transport)

logger.info('hi');
```


The error before this fix was:

```
{"name":"mockotlpserver","level":50,"err":{"message":"Cannot convert undefined or null to object","name":"TypeError","stack":"TypeError: Cannot convert undefined or null to object\n    at Function.keys (<anonymous>)\n    at LogsSummaryPrinter.printLogs (/Users/trentm/el/elastic-otel-node/packages/mockotlpserver/lib/logs-summary.js:94:32)\n    at /Users/trentm/el/elastic-otel-node/packages/mockotlpserver/lib/printers.js:81:26\n    at Channel.publish (node:diagnostics_channel:56:9)\n    at IncomingMessage.<anonymous> (/Users/trentm/el/elastic-otel-node/packages/mockotlpserver/lib/http.js:183:28)\n    at IncomingMessage.emit (node:events:517:28)\n    at endReadableNT (node:internal/streams/readable:1368:12)\n    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)"},"msg":"LogsSummaryPrinter.printLogs() threw","time":"2024-05-02T23:28:39.496Z"}
```

Pretty printed, that is:

```
{
  "name": "mockotlpserver",
  "level": 50,
  "err": {
    "message": "Cannot convert undefined or null to object",
    "name": "TypeError",
    "stack": "TypeError: Cannot convert undefined or null to object\n    at Function.keys (<anonymous>)\n    at LogsSummaryPrinter.printLogs (/Users/trentm/el/elastic-otel-node/packages/mockotlpserver/lib/logs-summary.js:94:32)\n    at /Users/trentm/el/elastic-otel-node/packages/mockotlpserver/lib/printers.js:81:26\n    at Channel.publish (node:diagnostics_channel:56:9)\n    at IncomingMessage.<anonymous> (/Users/trentm/el/elastic-otel-node/packages/mockotlpserver/lib/http.js:183:28)\n    at IncomingMessage.emit (node:events:517:28)\n    at endReadableNT (node:internal/streams/readable:1368:12)\n    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)"
  },
  "msg": "LogsSummaryPrinter.printLogs() threw",
  "time": "2024-05-02T23:28:39.496Z"
}

err.stack is:

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at LogsSummaryPrinter.printLogs (/Users/trentm/el/elastic-otel-node/packages/mockotlpserver/lib/logs-summary.js:94:32)
    at /Users/trentm/el/elastic-otel-node/packages/mockotlpserver/lib/printers.js:81:26
    at Channel.publish (node:diagnostics_channel:56:9)
    at IncomingMessage.<anonymous> (/Users/trentm/el/elastic-otel-node/packages/mockotlpserver/lib/http.js:183:28)
    at IncomingMessage.emit (node:events:517:28)
    at endReadableNT (node:internal/streams/readable:1368:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
```