### PR TITLE
examples: play with instrumenting Azure SDK usage

### DIFF
--- a/examples/.npmrc
+++ b/examples/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/examples/azure-instr.js
+++ b/examples/azure-instr.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Setup the Elastic OTel Node.js distro, along with extra Azure instrumentation.
+// Usage: node -r ./azure-instr.js SCRIPT.js
+
+const os = require('os');
+const path = require('path');
+
+const {
+    ElasticNodeSDK,
+    getInstrumentations,
+} = require('@elastic/opentelemetry-node/sdk');
+
+const {
+    createAzureSdkInstrumentation,
+} = require('@azure/opentelemetry-instrumentation-azure-sdk');
+
+const sdk = new ElasticNodeSDK({
+    serviceName: path.parse(process.argv[1]).name,
+    instrumentations: [
+        getInstrumentations(), // the default set of instrumentations
+        createAzureSdkInstrumentation(),
+    ],
+});
+
+process.on('SIGTERM', async () => {
+    try {
+        await sdk.shutdown();
+    } catch (err) {
+        console.warn('warning: error shutting down OTel SDK', err);
+    }
+    process.exit(128 + os.constants.signals.SIGTERM);
+});
+
+process.once('beforeExit', async () => {
+    // Flush recent telemetry data if about the shutdown.
+    try {
+        await sdk.shutdown();
+    } catch (err) {
+        console.warn('warning: error shutting down OTel SDK', err);
+    }
+});
+
+sdk.start();

--- a/examples/azure-storage-blob.js
+++ b/examples/azure-storage-blob.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Start an HTTP server and make a request to it.
+// Usage:
+//  node -r @elastic/opentelemetry-node XXX simple-http-request.js
+
+const otel = require('@opentelemetry/api');
+const {DefaultAzureCredential} = require('@azure/identity');
+const {BlobServiceClient} = require('@azure/storage-blob');
+
+async function main() {
+    const account = 'trentmstorage1';
+    const defaultAzureCredential = new DefaultAzureCredential();
+    const blobServiceClient = new BlobServiceClient(
+        `https://${account}.blob.core.windows.net`,
+        defaultAzureCredential
+    );
+
+    let i = 0;
+    for await (const container of blobServiceClient.listContainers()) {
+        console.log(`Container ${++i}: ${container.name}`);
+    }
+    if (i === 0) {
+        console.log('Account has no storage blob containers.');
+    }
+
+    // // Create a container
+    // const containerName = `newcontainer${new Date().getTime()}`;
+    // const containerClient = blobServiceClient.getContainerClient(containerName);
+    // const createContainerResponse = await containerClient.create();
+    // console.log(
+    //     `Create container ${containerName} successfully`,
+    //     createContainerResponse.requestId
+    // );
+}
+
+const tracer = otel.trace.getTracer('example');
+tracer.startActiveSpan('manual-span', async (span) => {
+    await main();
+    span.end();
+});

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,7 +5,10 @@
   "version": "0.1.0",
   "scripts": {},
   "devDependencies": {
-    "@elastic/opentelemetry-node": "*",
+    "@azure/identity": "^4.2.0",
+    "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
+    "@azure/storage-blob": "^12.17.0",
+    "@elastic/opentelemetry-node": "../packages/opentelemetry-node",
     "bunyan": "^1.8.15",
     "express": "^4.19.2"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "workspaces": [
-        "packages/*",
-        "examples"
+        "packages/*"
       ],
       "dependencies": {
         "@elastic/opentelemetry-node": "file:./packages/opentelemetry-node"
@@ -30,16 +29,6 @@
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
         "typescript": "^4.4.4"
-      }
-    },
-    "examples": {
-      "name": "elastic-otel-node-examples",
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "devDependencies": {
-        "@elastic/opentelemetry-node": "*",
-        "bunyan": "^1.8.15",
-        "express": "^4.19.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3027,10 +3016,6 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/elastic-otel-node-examples": {
-      "resolved": "examples",
-      "link": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -10441,14 +10426,6 @@
     "ee-first": {
       "version": "1.1.1",
       "dev": true
-    },
-    "elastic-otel-node-examples": {
-      "version": "file:examples",
-      "requires": {
-        "@elastic/opentelemetry-node": "*",
-        "bunyan": "^1.8.15",
-        "express": "^4.19.2"
-      }
     },
     "emoji-regex": {
       "version": "8.0.0"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "elastic-otel-node",
   "version": "0.1.0",
   "workspaces": [
-    "packages/*",
-    "examples"
+    "packages/*"
   ],
   "license": "Apache-2.0",
   "private": true,

--- a/packages/mockotlpserver/lib/waterfall.js
+++ b/packages/mockotlpserver/lib/waterfall.js
@@ -77,25 +77,25 @@ function renderSpan(span, prefix = '') {
                     BigInt(lastRenderedSpan.startTimeUnixNano)
             ) / 1e6;
         let unit = 'ms';
-        if (startOffset >= 1000) {
+        if (Math.abs(startOffset) >= 1000) {
             startOffset /= 1000;
-            unit = 's';
+            unit = 's ';
         }
-        if (startOffset >= 1000) {
+        if (Math.abs(startOffset) >= 1000) {
             startOffset /= 60;
-            unit = 'm'; // minutes
+            unit = 'm '; // minutes
         }
-        if (startOffset >= 1000) {
+        if (Math.abs(startOffset) >= 1000) {
             startOffset /= 60;
-            unit = 'h';
+            unit = 'h ';
         }
-        if (startOffset >= 1000) {
+        if (Math.abs(startOffset) >= 1000) {
             // Seems unlikely we'll receive a trace with *days* of offset. :)
             startOffset /= 24;
-            unit = 'd';
+            unit = 'd ';
         }
-        gutter = `${startOffset >= 0 ? '+' : '-'}${Math.floor(startOffset)}`;
-        gutter = `${' '.repeat(4 - gutter.length)}${gutter}${unit}`;
+        gutter = `${startOffset >= 0 ? '+' : ''}${Math.round(startOffset)}`;
+        gutter = `${' '.repeat(Math.max(4 - gutter.length, 0))}${gutter}${unit}`;
     } else {
         gutter = ' '.repeat(6);
     }


### PR DESCRIPTION
- Shows using a 3rd party instrumentation (see azure-instr.js bootstrap script)

Also:
- Remove examples/ from the workspace, so we can freely add deps to it without
  burdening the top-level builds for CI and dev-use not using the examples.
- Fix a bug in the trace waterfall handling of the gutter in mockotlpserver.
  It was not handling negative start offset values. Spacing was also wrong
  for the single-char time units.
