### PR TITLE
chore: limit updates to aws-sdk-related packages to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,18 +12,33 @@ updates:
       # 'npm run maint:update-otel-deps' instead. See
       # https://github.com/elastic/elastic-otel-node/pull/68 for details.
       - dependency-name: "@opentelemetry/*"
+      # AWS SDK-related deps are handled in the less-frequent dependabot block
+      # below.
+      - dependency-name: "@aws-sdk/*"
+      - dependency-name: "@smithy/*"
     groups:
       eslint:
         dependency-type: "development"
         patterns:
         - "eslint*"
-      aws-sdk:
-        dependency-type: "development"
-        patterns:
-        - "@aws-sdk/client-*"
       patch-level:
         update-types:
         - "patch"
+
+  # Less frequent updates to some less important but frequently-released deps.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "@aws-sdk/*"
+      - dependency-name: "@smithy/*"
+    groups:
+      aws-sdk:
+        dependency-type: "development"
+        patterns:
+        - "@aws-sdk/*"
+        - "@smithy/*"
 
   # GitHub actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
This is a follow-up to #195 to attempt to get updates for
aws-sdk without all the noise.
