### PR TITLE
chore: add new internal issues/PRs to GH project

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,5 @@
-name: "Issue Labeler"
+# Tweak incoming issues/PRs: labeling and/or adding to GH projects.
+name: "labeler"
 on:
   issues:
     types: [opened]
@@ -12,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  triage:
+  categorize-issues-and-prs:
     runs-on: ubuntu-latest
     steps:
     - id: is_elastic_member
@@ -32,3 +33,11 @@ jobs:
             repo: context.repo.repo,
             labels: ["community", "triage"]
           })
+
+    - name: Assign new internal issues and PRs to project
+      uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e  # v1.0.2
+      if: contains(steps.is_elastic_member.outputs.result, 'true')
+      with:
+        project-url: 'https://github.com/orgs/elastic/projects/1397'
+        github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
+


### PR DESCRIPTION
Closes: #108

---

@elastic/observablt-robots Do you think the token I'm using here will work? Here is the relevant part of the "add-to-project" action README that discusses the token/PAT permissions required: https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository