### PR TITLE
feat(mockotlpserver): Dockerfile and docs on using it in Kubernetes

### DIFF
--- a/packages/mockotlpserver/Dockerfile
+++ b/packages/mockotlpserver/Dockerfile
@@ -1,0 +1,16 @@
+# Usage:
+#   docker build -t mockotlpserver .
+#   docker run --rm -it -p 4317:4317 -p 4318:4318 --name mockotlpserver mockotlpserver
+#
+# Or see "share/k8s/README.md" for using it with Kubernetes.
+FROM node:18-alpine
+RUN mkdir /app
+WORKDIR /app
+COPY lib ./lib/
+COPY opentelemetry ./opentelemetry/
+COPY ui ./ui/
+COPY package.json ./
+COPY README.md LICENSE NOTICE.md ./
+RUN npm install
+EXPOSE 4317 4318
+CMD ["npm", "start", "--", "--hostname=0.0.0.0"]

--- a/packages/mockotlpserver/share/k8s/README.md
+++ b/packages/mockotlpserver/share/k8s/README.md
@@ -1,0 +1,171 @@
+This directory includes support files and details showing how to
+deploy the `mockotlpserver` to a Kubernetes cluster.
+
+# How to setup mockotlpserver in a local Kubernetes cluster
+
+This shows how to setup [mockotlpserver](../../) as a service running in a
+[kind](https://kind.sigs.k8s.io/) Kubernetes cluster (a small k8s cluster
+running locally in Docker).
+
+1. Have Docker running. If you are using Docker for Mac, I do **not** have the
+   built-in optional k8s cluster from Docker desktop running. I'm not sure if it
+   will interfere.
+2. Install `kind` (https://kind.sigs.k8s.io/docs/user/quick-start/#installation).
+3. Run the following commands:
+
+```sh
+# Start a local Docker registry (at localhost:5001, used to hold locally-built
+# images that will be used in the Kubernetes cluster) and a Kind cluster
+# configured to use it.
+./create-kind-cluster-with-registry.sh
+
+# Build and publish the Docker image for mockotlpserver.
+docker build -t mockotlpserver ../..
+docker tag mockotlpserver localhost:5001/mockotlpserver
+docker push localhost:5001/mockotlpserver
+
+# Deploy the mockotlpserver service.
+kubectl apply -f ./mockotlpserver-service.yaml
+kubectl apply -f ./mockotlpserver-deployment.yaml
+```
+
+If that worked then `kubectl get all` should show a "pod/mockotlpserver-*" Pod in
+which the server will be running and a "service/mockotlpserver" that defines the
+service. For example:
+
+```
+% kubectl get all
+NAME                                  READY   STATUS    RESTARTS   AGE
+pod/mockotlpserver-845f7d8489-q844c   1/1     Running   0          8s
+
+NAME                     TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+service/kubernetes       ClusterIP   10.96.0.1      <none>        443/TCP    27s
+service/mockotlpserver   ClusterIP   10.96.20.238   <none>        8200/TCP   8s
+
+NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/mockotlpserver   1/1     1            1           8s
+
+NAME                                        DESIRED   CURRENT   READY   AGE
+replicaset.apps/mockotlpserver-845f7d8489   1         1         1       8s
+```
+
+Other containers running in the same cluster should be able to use the OTLP
+server at `http://mockotlpserver:4317` for gRPC or at port 4318 for HTTP.
+
+Remember to [clean up](#clean-up) after you are done.
+
+
+# Accessing the `mockotlpserver` from the host
+
+To verify the server is running, let's call it from the host -- i.e. from your
+laptop/computer. To reach the mockotlpserver endpoint the pod's ports will
+need to be forwarded to the host. For development this can be temporarily done
+via `kubectl port-forward`.
+
+In one terminal run:
+
+```sh
+kubectl port-forward service/mockotlpserver 4317 4318
+```
+
+In another terminal, curl the server:
+
+```
+% curl -i localhost:4318
+HTTP/1.1 400 Bad Request
+Date: Tue, 09 Jul 2024 23:55:29 GMT
+Connection: keep-alive
+Keep-Alive: timeout=5
+Transfer-Encoding: chunked
+
+{"error":{"code":400,"message":"Invalid or no data received"}}
+```
+
+This shows that the server is listening. This isn't a valid OTLP request so
+we expect the HTTP 400 error.
+
+If you *require* access to the mockotlpserver from the host more permanently
+(i.e. without having to have `kubectl port-forward` running), then you'll need
+to look into setting `hostPort` for the Pod (perhaps via a setting on the
+Deployment config?).
+
+
+# Example using the mockotlpserver
+
+Let's run a small app in our Kubernetes cluster that uses the mockotlpserver to
+see it working. "example-app-manual/" holds a small Express-based HTTP app
+with a single `GET /ping` endpoint. There is a Kubernetes deployment config
+to instrument the app with the Elastic Distribution for OpenTelemetry Node.js
+(an wrapper around the OpenTelemetry SDK).
+
+```sh
+cd example-app-manual
+
+# Build the Docker image.
+docker build -t example-app-manual .
+docker tag example-app-manual localhost:5001/example-app-manual
+docker push localhost:5001/example-app-manual
+
+# Deploy a single instance of this app, instrumented with an OpenTelemetry SDK
+# (via 'NODE_OPTIONS') and configured to send data to the mockotlpserver
+# (via 'OTEL_EXPORTER_OTLP_ENDPOINT').
+kubectl apply -f ./deployment.yaml
+```
+
+If this worked, then the logs for the example-app-manual pod will show the
+Elastic distribution for OpenTelemetry Node.js (`@elastic/opentelemetry-node`)
+has started, and a number of "server /ping" requests (one from "app.js"
+itself, the others from the Kubernetes deployment "livenessProbe"):
+
+```sh
+% kubectl get pods
+NAME                                  READY   STATUS    RESTARTS   AGE
+example-app-manual-7b9765b4f9-v5bkk   1/1     Running   0          41s
+mockotlpserver-845f7d8489-q844c       1/1     Running   0          71m
+
+% kubectl logs -f deployment.apps/example-app-manual
+...
+
+> example-app-manual@1.0.0 start
+> node app.js
+
+{"name":"elastic-otel-node","level":30,"preamble":true,"distroVersion":"0.1.3","env":{"os":"linux 6.6.32-linuxkit","arch":"arm64","runtime":"Node.js v18.20.4"},"msg":"start Elastic Distribution for OpenTelemetry Node.js","time":"2024-07-10T00:17:58.129Z"}
+...
+Listening on { address: '0.0.0.0', family: 'IPv4', port: 3000 }
+[2024-07-10T00:18:00.510Z] server /ping
+[2024-07-10T00:18:06.920Z] server /ping
+[2024-07-10T00:18:16.923Z] server /ping
+...
+```
+
+As well, the logs from "service/mockotlpserver" will show requests being made from the OpenTelemetry SDK running in the app's process:
+
+```
+% kubectl logs -f service/mockotlpserver
+...
+------ trace e3bce8 (4 spans) ------
+       span 700100 "GET /ping" (1.6ms, SPAN_KIND_SERVER, GET http://10.244.0.14:3000/ping -> 200)
+  +0ms `- span 1fe07b "middleware - query" (0.1ms, SPAN_KIND_INTERNAL)
+  +1ms `- span 0576c8 "middleware - expressInit" (0.1ms, SPAN_KIND_INTERNAL)
+  +0ms `- span cb7eac "request handler - /ping" (0.0ms, SPAN_KIND_INTERNAL)
+...
+------ metrics ------
+      http.client.request.duration (histogram, s, 5 attrs): min=0.021940459, max=0.021940459
+...
+```
+
+Clean up:
+
+```
+kubectl delete deployment example-app-manual
+```
+
+
+# Clean up
+
+When you are done.
+
+```
+kind delete cluster --name=kind
+docker kill kind-registry
+```

--- a/packages/mockotlpserver/share/k8s/create-kind-cluster-with-registry.sh
+++ b/packages/mockotlpserver/share/k8s/create-kind-cluster-with-registry.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# Create a local Docker registry and a Kind cluster configured to use it.
+# This is adapted from "kind-with-registry.sh" from
+# https://kind.sigs.k8s.io/docs/user/local-registry/
+#
+
+set -o errexit
+
+# 1. Create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5001'
+if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+  echo "Creating docker registry '${reg_name}' at localhost:5001 ..."
+  docker run \
+    --rm -d -p "127.0.0.1:${reg_port}:5000" --network bridge --name "${reg_name}" \
+    registry:2
+fi
+
+# 2. Create kind cluster with containerd registry config dir enabled
+# TODO: kind will eventually enable this by default and this patch will
+# be unnecessary.
+#
+# See:
+# https://github.com/kubernetes-sigs/kind/issues/2875
+# https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
+# See: https://github.com/containerd/containerd/blob/main/docs/hosts.md
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
+nodes:
+- role: control-plane
+  # Optional. To expose the mockotlpserver ports to the host per https://kind.sigs.k8s.io/docs/user/configuration/#extra-port-mappings
+  #extraPortMappings:
+  #- containerPort: 4317
+  #  hostPort: 4317
+  #  protocol: TCP
+  #- containerPort: 4318
+  #  hostPort: 4318
+  #  protocol: TCP
+EOF
+
+# 3. Add the registry config to the nodes
+#
+# This is necessary because localhost resolves to loopback addresses that are
+# network-namespace local.
+# In other words: localhost in the container is not localhost on the host.
+#
+# We want a consistent name that works from both ends, so we tell containerd to
+# alias localhost:${reg_port} to the registry container when pulling images
+REGISTRY_DIR="/etc/containerd/certs.d/localhost:${reg_port}"
+for node in $(kind get nodes); do
+  docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
+  cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
+[host."http://${reg_name}:5000"]
+EOF
+done
+
+# 4. Connect the registry to the cluster network if not already connected
+# This allows kind to bootstrap the network but ensures they're on the same network
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
+  docker network connect "kind" "${reg_name}"
+fi
+
+# 5. Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+

--- a/packages/mockotlpserver/share/k8s/example-app-manual/.npmrc
+++ b/packages/mockotlpserver/share/k8s/example-app-manual/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/mockotlpserver/share/k8s/example-app-manual/Dockerfile
+++ b/packages/mockotlpserver/share/k8s/example-app-manual/Dockerfile
@@ -1,0 +1,11 @@
+# Vanilla usage in Docker:
+#    docker build -t example-app-manual .
+#    docker run --rm -it -p 3000:3000 example-app-manual
+#    curl -i http://127.0.0.1:3000/ping
+FROM node:18-alpine
+RUN mkdir /app
+WORKDIR /app
+COPY app.js package.json ./
+RUN npm install
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/packages/mockotlpserver/share/k8s/example-app-manual/app.js
+++ b/packages/mockotlpserver/share/k8s/example-app-manual/app.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// A simple Express app with a `GET /ping` endpoint.
+const express = require('express');
+
+const app = express();
+app.get('/ping', function ping(req, res, next) {
+    console.log('[%s] server /ping', new Date().toISOString());
+    res.send('pong');
+});
+app.use(function onError(err, req, res, next) {
+    res.status(500);
+    res.send(`internal error: ${err.message}`);
+});
+
+const server = app.listen(3000, '0.0.0.0', () => {
+    console.log('Listening on', server.address());
+});
+
+// Call this local server after a couple seconds so we have trace data from
+// at least one request.
+setTimeout(async () => {
+    await fetch('http://127.0.0.1:3000/ping');
+}, 2000);

--- a/packages/mockotlpserver/share/k8s/example-app-manual/deployment.yaml
+++ b/packages/mockotlpserver/share/k8s/example-app-manual/deployment.yaml
@@ -1,0 +1,37 @@
+# A Kubernetes deployment config for this app.
+# Usage:
+#     docker build -t example-app-manual .
+#     docker tag example-app-manual localhost:5001/example-app-manual
+#     docker push localhost:5001/example-app-manual
+#     kubectl apply -f ./deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: example-app-manual
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-app-manual
+  template:
+    metadata:
+      labels:
+        app: example-app-manual
+    spec:
+      containers:
+      - name: example-app-manual
+        image: localhost:5001/example-app-manual
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_OPTIONS
+          value: "--require=@elastic/opentelemetry-node"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://mockotlpserver:4318"
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 3000
+          initialDelaySeconds: 1
+          periodSeconds: 10

--- a/packages/mockotlpserver/share/k8s/example-app-manual/package.json
+++ b/packages/mockotlpserver/share/k8s/example-app-manual/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "example-app-manual",
+  "version": "1.0.0",
+  "private": true,
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "@elastic/opentelemetry-node": "*",
+    "express": "^4.18.2"
+  }
+}

--- a/packages/mockotlpserver/share/k8s/mockotlpserver-deployment.yaml
+++ b/packages/mockotlpserver/share/k8s/mockotlpserver-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mockotlpserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+     app: mockotlpserver
+  template:
+    metadata:
+      labels:
+        app: mockotlpserver
+    spec:
+      containers:
+      - name: mockotlpserver
+        image: localhost:5001/mockotlpserver
+        ports:
+        - containerPort: 4317
+        - containerPort: 4318

--- a/packages/mockotlpserver/share/k8s/mockotlpserver-service.yaml
+++ b/packages/mockotlpserver/share/k8s/mockotlpserver-service.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: mockotlpserver
+spec:
+  selector:
+    app: mockotlpserver
+  ports:
+  - name: otlp-grpc
+    protocol: TCP
+    port: 4317
+    targetPort: 4317
+  - name: otlp-http
+    protocol: TCP
+    port: 4318
+    targetPort: 4318


### PR DESCRIPTION
This adds a Dockerfile that could be used later to publish image builds.
It also adds docs and Kubernetes deployment config to show how to
use mockotlpserver in k8s.
