### PR TITLE
feat(mockotlpserver): handle logs and metrics via gRPC

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -1,7 +1,9 @@
 # @elastic/mockotlpserver Changelog
 
-## untagged
+## v0.3.0
 
+- Update gRPC server to accept metrics (MetricsService) and logs (LogsService).
+  (https://github.com/elastic/elastic-otel-node/pull/277)
 - Added a start at better metrics support:
     - The `jsonN` output modes will some a somewhat normalized JSON
       representation (similar to what is done to normalize trace request data).

--- a/packages/mockotlpserver/lib/normalize.js
+++ b/packages/mockotlpserver/lib/normalize.js
@@ -381,6 +381,15 @@ function jsonStringifyLogs(logs, opts) {
                     rv = Buffer.from(v.data).toString('hex');
                 }
                 break;
+            case 'timeUnixNano':
+            case 'observedTimeUnixNano':
+                // OTLP/gRPC time fields are `Long` (https://github.com/dcodeIO/Long.js),
+                // converted to a plain object. Convert them to a string to
+                // match the other flavour.
+                if (typeof v === 'object' && 'low' in v) {
+                    rv = new Long(v.low, v.high, v.unsigned).toString();
+                }
+                break;
         }
         return rv;
     };

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "commonjs",
   "description": "Elastic OLTP mock server for Node.js",
   "private": true,


### PR DESCRIPTION
Before this the gRPC server hadn't yet added the LogsService and MetricsService.

Fixes: #276
