### PR TITLE
chore(dependabot): drop separate 'monthly' block for updating some npm deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,6 @@ updates:
       # 'npm run maint:update-otel-deps' instead. See
       # https://github.com/elastic/elastic-otel-node/pull/68 for details.
       - dependency-name: "@opentelemetry/*"
-      # AWS SDK-related deps are handled in the less-frequent dependabot block
-      # below.
-      - dependency-name: "@aws-sdk/*"
-      - dependency-name: "@smithy/*"
       # eslint-related deps are skipped until we have upgraded to eslint@9
       # https://github.com/elastic/elastic-otel-node/pull/155
       - dependency-name: "eslint*"
@@ -27,6 +23,11 @@ updates:
       - dependency-name: "minimatch" # minimatch@10 dropped 14, 16, 18
         versions: [ ">=10" ]
     groups:
+      aws-sdk:
+        dependency-type: "development"
+        patterns:
+        - "@aws-sdk/*"
+        - "@smithy/*"
       # eslint:
       #   dependency-type: "development"
       #   patterns:
@@ -35,21 +36,6 @@ updates:
       patch-level:
         update-types:
         - "patch"
-
-  # Less frequent updates to some less important but frequently-released deps.
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-name: "@aws-sdk/*"
-      - dependency-name: "@smithy/*"
-    groups:
-      aws-sdk:
-        dependency-type: "development"
-        patterns:
-        - "@aws-sdk/*"
-        - "@smithy/*"
 
   # GitHub actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Today I noticed a new check failure on the latest commit to main. It was to
dependabot.yml. The failure:
> Your .github/dependabot.yml contained invalid details
> Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'npm' has overlapping directories.

I don't know if this is a new constraint or was just not noticed before.
I am hoping dropping the 'monthly' block here will suffice. We will
just deal with aws-sdk updates weekly, distracting though that will be.
