### PR TITLE
chore: add a convenience Makefile; fix mssql service in docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: all
 all:
-	npm ci
+	npm run ci-all
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# This is pure a convenience wrapper around calling npm scripts for those
+# with `make` in their veins. Though shalt not add complex logic here.
+
+.PHONY: all
+all:
+	npm ci
+
+.PHONY: lint
+lint:
+	npm run lint
+
+.PHONY: test
+test:
+	cd packages/opentelemetry-node \
+		&& npm run test-services:start \
+		&& npm test \
+		&& npm run test-services:stop
+

--- a/packages/opentelemetry-node/test/docker-compose.yaml
+++ b/packages/opentelemetry-node/test/docker-compose.yaml
@@ -46,7 +46,9 @@ services:
       retries: 30
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    # Tags listed at https://hub.docker.com/r/microsoft/mssql-server
+    # Docs: https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker
+    image: mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04
     platform: linux/amd64
     environment:
       - ACCEPT_EULA=Y
@@ -54,7 +56,7 @@ services:
     ports:
       - "1433:1433"
     healthcheck:
-      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "mssql", "-U", "sa", "-P", "Very(!)Secure", "-Q", "select 1"]
-      interval: 30s
+      test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "mssql", "-U", "sa", "-P", "Very(!)Secure", "-Q", "select 1"]
+      interval: 1s
       timeout: 10s
-      retries: 5
+      retries: 30


### PR DESCRIPTION
First, add a Makefile for those with 'make' in their blood:

    make all test

Also fix mssql image usage after breakage in the latest release, copying
what was done in https://github.com/elastic/apm-agent-nodejs/pull/4150
