### PR TITLE
release @elastic/opentelemetry-node@0.3.0

### DIFF
--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/opentelemetry-node Changelog
 
-## Unreleased
+## v0.3.0
 
 - Bump minimum supported Node.js version to v14.18.0.
   (Previously it was v14.17.0.)

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-node",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",
@@ -86,7 +86,7 @@
         "winston": "^3.13.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.18.0"
       }
     },
     "../mockotlpserver": {

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "commonjs",
   "description": "Elastic Distribution for OpenTelemetry Node.js",
   "publishConfig": {


### PR DESCRIPTION
Highlights:
- we added a number of instrumentations (still from the upstream auto-instrumentations-node set of instrs)