### PR TITLE
chore: convenience 'npm run oneach -- CMD...'

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "ci-all": "set -e; ls -d . packages/* examples | while read d; do (cd $d; echo; echo \"> $d\"; npm ci); done",
     "clean-all": "ls -d . packages/* examples | while read d; do (cd $d; echo \"> $d\"; rm -rf node_modules); done",
-    "each": "echo XXX each",
+    "oneach": "./scripts/oneach.sh",
     "lint": "npm run lint:eslint && ls -d packages/* | while read d; do (cd $d; npm run lint); done",
     "lint:eslint": "eslint --ext=js,mjs,cjs scripts examples # requires node >=16.0.0",
     "lint:fix": "eslint --ext=js,mjs,cjs .eslintrc.js scripts examples --fix && ls -d packages/* | while read d; do (cd $d; npm run lint:fix); done",

--- a/scripts/oneach.sh
+++ b/scripts/oneach.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# This script runs the the given argv in each package dir in this repo.
+# Basically this is something of a replacement for `npm run --workspaces ...`
+# since this repo no longer uses npm workspaces.
+#
+# Usage:
+#   npm run oneach -- COMMAND [ARGS...]
+#
+# Examples:
+#   npm run oneach -- npm ls
+#
+
+if [ "$TRACE" != "" ]; then
+    export PS4='${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+    set -o xtrace
+fi
+# Note: explicitly NOT setting errexit and pipefail so that we continue on error.
+
+# ---- support functions
+
+function warn {
+    echo "$(basename $0): warn: $*" >&2
+}
+
+function fatal {
+    echo "$(basename $0): error: $*" >&2
+    exit 1
+}
+
+# ---- mainline
+
+TOP=$(cd $(dirname $0)/../ >/dev/null; pwd)
+PKGDIRS=$(ls -d packages/* examples .)
+CMD="$@"
+
+finalRetval=0
+for pkgDir in $PKGDIRS; do
+    echo
+
+    echo -e "\033[90m> $pkgDir\033[0m"
+    (cd $pkgDir && $CMD)
+    retval=$?
+    if [[ $retval -ne 0 ]]; then
+        echo -e "\033[31m> non-zero exit status in '$pkgDir': $retval\033[0m"
+        finalRetval=1
+    fi
+done
+
+exit $finalRetval


### PR DESCRIPTION
This is a convenience to run a command in each package dir.
Now that we are no longer using npm workspaces, we cannot
'npm run --workspaces ...'. This is mostly similar, except
it is a general command, not an npm script, that is run.
E.g.: npm run oneach -- npm ls @opentelemetry/sdk-node
