### PR TITLE
fix(mockotlpserver): bump up the depth on 'inspect' printer to always see the full data structure

### DIFF
--- a/packages/mockotlpserver/lib/printers.js
+++ b/packages/mockotlpserver/lib/printers.js
@@ -101,7 +101,7 @@ class InspectPrinter extends Printer {
         super(log);
         /** @private */
         this._inspectOpts = {
-            depth: 13, // Need 13 to get full metrics data structure.
+            depth: 100, // Need 13 for full metrics data structure, more for some logs.
             breakLength: process.stdout.columns || 120,
         };
         this._signals = signals;


### PR DESCRIPTION
When playing with deep log records, e.g. with:

```js
logger.info('the message', {
  aNum: 42,
  aStr: 'str',
  aUint8Array: new Uint8Array([4,5,6]),
  aInt8Array: new Int8Array([-7,8,9]),
  anObj: {
    numField: 43,
    strField: 'str',
    uint8ArrayField: new Uint8Array([10,11,12]),
  },
});
```

the current depth wasn't showing the full object structure.