### PR TITLE
fix(mockotlpserver): support doubleValue attributes; improve rendering of log events where the body is typically an object, not a string

### DIFF
--- a/packages/mockotlpserver/lib/normalize.js
+++ b/packages/mockotlpserver/lib/normalize.js
@@ -66,6 +66,8 @@ function normAttrValue(v) {
         return v.stringValue;
     } else if ('boolValue' in v) {
         return v.boolValue;
+    } else if ('doubleValue' in v) {
+        return v.doubleValue;
     } else if ('arrayValue' in v) {
         return v.arrayValue.values.map(normAttrValue);
     } else if ('intValue' in v) {
@@ -102,7 +104,9 @@ function normAttrValue(v) {
         // This normalization will use `null`.
         return null;
     }
-    throw new Error(`unexpected type of attributes value: ${v}`);
+    throw new Error(
+        `unexpected type of attributes value: ${JSON.stringify(v)}`
+    );
 }
 
 /**


### PR DESCRIPTION
Two things:

1. There was a crash when an attribute with `doubleValue` was being rendered. That's the fix in normalize.js.
2. The "log-summary" printer's rendering of events (https://opentelemetry.io/docs/specs/otel/logs/event-sdk/#emit-event) which typically (always?) have a structured Body and have no `severityText` sucked. This improves that.

E.g.:

```
------ logs (2 records) ------
[2024-08-14T01:14:13.685000000Z] SEV-9 (instrumentation-openai-js-example):
    hi from patchedCreate
    asdf
        if True:
            print hi
    --
    foo: 'bar'
[2024-08-14T01:14:13.685000000Z] SEV-9 (instrumentation-openai-js-example): Event a-domain.a-event
    {
      field1: 'def',
      field2: 42.42
    }
    --
    'event.name': 'a-domain.a-event'
```

for these OTel JS calls:

```js
        const logger = logs.getLogger(pj.name, pj.version);
        logger.emit({
          timestamp: Date.now(),
          severityNumber: SeverityNumber.INFO,
          body: 'hi from patchedCreate\nasdf\n    if True:\n        print hi',
          attributes: {
            foo: 'bar'
          }
        });
        const eventLogger = events.getEventLogger(pj.name, pj.version);
        eventLogger.emit({
          name: 'a-domain.a-event',
          data: {
            field1: 'def',
            field2: 42.42
          }
        });
```