### PR TITLE
fix(mockotlpserver): fix normalization of empty kvlistValue attributes

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## untagged
 
+- Fix normalization of *empty* `kvlistValue` attributes.
+- Improve "logs-summary" rendering of "Events" (log records with a `event.name`
+  attribute) and log record `Body` fields that are multi-line strings or
+  structured objects. Before this change the summary rendering was assuming
+  the `Body` was a single-line string (typical of log record messages).
+- Support `doubleValue` attributes.
 - Support `bytesValue` attributes.
 - Support `boolValue` attributes. I first saw this with:
     ```

--- a/packages/mockotlpserver/lib/normalize.js
+++ b/packages/mockotlpserver/lib/normalize.js
@@ -86,8 +86,10 @@ function normAttrValue(v) {
         }
     } else if ('kvlistValue' in v) {
         const obj = {};
-        for (let keyValue of v.kvlistValue.values) {
-            obj[keyValue.key] = normAttrValue(keyValue.value);
+        if (v.kvlistValue.values) {
+            for (let keyValue of v.kvlistValue.values) {
+                obj[keyValue.key] = normAttrValue(keyValue.value);
+            }
         }
         return obj;
     } else if ('bytesValue' in v) {


### PR DESCRIPTION
The error was: 'TypeError: v.kvlistValue.values is not iterable'
