### PR TITLE
feat(mockotlpserver): show some GenAI-related span details in trace summary view

### DIFF
--- a/packages/mockotlpserver/lib/waterfall.js
+++ b/packages/mockotlpserver/lib/waterfall.js
@@ -131,6 +131,21 @@ function renderSpan(span, prefix = '') {
                 .join(' ')
         );
     }
+    // GenAI-related extras
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.27.0/model/registry/gen-ai.yaml
+    if ('gen_ai.system' in attrs) {
+        extras.push(`GenAI ${attrs['gen_ai.system']}`);
+        try {
+            extras.push(
+                `finish_reasons=${attrs['gen_ai.response.finish_reasons'].join(
+                    ','
+                )}`
+            );
+            extras.push(
+                `tokens ${attrs['gen_ai.usage.input_tokens']}in/${attrs['gen_ai.usage.output_tokens']}out`
+            );
+        } catch (_err) {}
+    }
     if (extras.length) {
         r += ` (${extras.join(', ')})`;
     }


### PR DESCRIPTION
E.g.:

    span 99bb32 "chat llama3.1:latest" (7475.4ms, SPAN_KIND_CLIENT, GenAI openai, finish_reasons=tool_calls, tokens 209in/22out)

The part from "GenAI" on are the added extra attributes included.
This shows a subset of semconv v1.27 gen_ai attrs.
