### PR TITLE
chore(deps): tweak dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       opentelemetry:
         patterns:
         - "@opentelemetry/*"
-        - "@smithy/*"
       aws-sdk:
         dependency-type: "development"
         patterns:
@@ -29,7 +28,7 @@ updates:
     reviewers:
       - "elastic/apm-agent-node-js"
     groups:
-      repo-root:
+      mockotlpserver:
         patterns:
         - "*"
 


### PR DESCRIPTION
The inclusion of the smithy pattern in the opentelemetry group
was a mistake.
