### PR TITLE
release @elastic/mockotlpserver@0.4.1

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -1,8 +1,13 @@
 # @elastic/mockotlpserver Changelog
 
+## v0.4.1
+
+(First version published to npm.)
+
+- Fix "publishConfig" so npm publishing can work.
+
 ## v0.4.0
 
-- First version being published to npm.
 - Fix normalization of *empty* `kvlistValue` attributes.
 - Improve "logs-summary" rendering of "Events" (log records with a `event.name`
   attribute) and log record `Body` fields that are multi-line strings or

--- a/packages/mockotlpserver/package-lock.json
+++ b/packages/mockotlpserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/mockotlpserver",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.11.1",

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -1,8 +1,12 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "commonjs",
   "description": "A mock OTLP server, useful for dev and testing",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This sets publishConfig.access=public, required to publish a
scoped package -- scoped packages default to private.
