### PR TITLE
release @elastic/mockotlpserver@0.5.0

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: Add shebang line to the CLI script so `npx @elastic/mockotlpserver` works.
 - feat: Add `--log-level, -l LEVEL` option. E.g. `mockotlpserver -l warn` makes startup silent.
+  Also add a `logLevel` option to the `MockOtlpServer` class for module usage.
 
 ## v0.4.1
 

--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @elastic/mockotlpserver Changelog
 
+## v0.5.0
+
+- fix: Add shebang line to the CLI script so `npx @elastic/mockotlpserver` works.
+- feat: Add `--log-level, -l LEVEL` option. E.g. `mockotlpserver -l warn` makes startup silent.
+
 ## v0.4.1
 
 (First version published to npm.)

--- a/packages/mockotlpserver/lib/cli.js
+++ b/packages/mockotlpserver/lib/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. See the NOTICE file distributed with
@@ -94,12 +96,17 @@ const OPTIONS = [
         help: 'Print this help and exit.',
     },
     {
+        names: ['log-level', 'l'],
+        type: 'string',
+        help: `Set the log level to one of "trace", "debug", "info", "warn", "error", "fatal".`,
+        default: 'info',
+    },
+    {
         names: ['o'],
         type: 'arrayOfPrinters',
-        help: `Formats for printing OTLP data. One or more of "${PRINTER_NAMES.join(
+        help: `Output formats for printing OTLP data. Comma-separated, one or more of "${PRINTER_NAMES.join(
             '", "'
-        )}".`,
-        default: ['inspect', 'summary'],
+        )}". Default: "inspect,summary"`,
     },
     {
         names: ['hostname'],
@@ -124,15 +131,23 @@ async function main() {
         log.error({err}, `${CMD}: command-line options error`);
         process.exit(1);
     }
+    log.level(opts.log_level);
     if (opts.help) {
         var help = parser.help({includeDefault: true}).trimRight();
         console.log(
             'Usage:\n' +
-                '    node lib/mockotlpserver.js [OPTIONS]\n' +
+                '    npx @elastic/mockotlpserver [OPTIONS]\n' +
+                '    mockotlpserver [OPTIONS]               # if installed globally\n' +
                 'Options:\n' +
                 help
         );
         process.exit(0);
+    }
+    if (!opts.o) {
+        // The way dashdash `--help` output prints the default of an array is
+        // misleading, so we'll apply the default here and manually document
+        // the default in the "help:" string above.
+        opts.o = ['inspect', 'summary'];
     }
 
     /** @type {Array<'http'|'grpc'|'ui'>} */
@@ -220,6 +235,8 @@ async function main() {
         }
     });
     printers.forEach((p) => p.subscribe());
+
+    log.trace({opts}, 'started');
 }
 
 main();

--- a/packages/mockotlpserver/lib/cli.js
+++ b/packages/mockotlpserver/lib/cli.js
@@ -236,7 +236,7 @@ async function main() {
     });
     printers.forEach((p) => p.subscribe());
 
-    log.trace({opts}, 'started');
+    log.trace({cliOpts: opts}, 'started');
 }
 
 main();

--- a/packages/mockotlpserver/lib/mockotlpserver.js
+++ b/packages/mockotlpserver/lib/mockotlpserver.js
@@ -61,6 +61,10 @@ class MockOtlpServer {
     /**
      * @param {object} [opts]
      * @param {import('./luggite').Logger} [opts.log]
+     * @param {string} [opts.logLevel] Optionally change the log level. This
+     *      accepts any of the log level names supported by luggite. Typically
+     *      one would use opts.log *or* opts.logLevel. The latter enables
+     *      tweaking the log level without having to pass in a custom logger.
      * @param {Array<'http'|'grpc'|'ui'>} [opts.services] Zero or more of 'http', 'grpc',
      *      and 'ui'. If not provided, then defaults to starting all services.
      * @param {string} [opts.httpHostname] Default 'localhost'.
@@ -76,6 +80,9 @@ class MockOtlpServer {
     constructor(opts) {
         opts = opts ?? {};
         this._log = opts.log ?? luggite.createLogger({name: 'mockotlpserver'});
+        if (opts.logLevel != null) {
+            this._log.level(opts.logLevel);
+        }
         this._services = opts.services ?? ['http', 'grpc', 'ui'];
         this._httpHostname = opts.httpHostname ?? DEFAULT_HOSTNAME;
         this._httpPort = opts.httpPort ?? DEFAULT_HTTP_PORT;

--- a/packages/mockotlpserver/package-lock.json
+++ b/packages/mockotlpserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/mockotlpserver",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.11.1",

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "commonjs",
   "description": "A mock OTLP server, useful for dev and testing",
   "publishConfig": {

--- a/packages/opentelemetry-node/test/testutils.js
+++ b/packages/opentelemetry-node/test/testutils.js
@@ -34,8 +34,6 @@ const {
     normalizeMetrics,
 } = require('@elastic/mockotlpserver');
 
-const luggite = require('../lib/luggite');
-
 /**
  * Filter out instr-dns and instr-net spans for testing.
  * Eventually it would be preferable to have each test run with instr-dns
@@ -534,11 +532,7 @@ function runTestFixtures(suite, testFixtures) {
 
                 const collector = new TestCollector();
                 const otlpServer = new MockOtlpServer({
-                    // Pass in a logger solely to reduce the level to warn.
-                    log: luggite.createLogger({
-                        name: 'mockotlpserver',
-                        level: 'warn',
-                    }),
+                    logLevel: 'warn',
                     services: ['http'],
                     httpHostname: '127.0.0.1', // avoid default 'localhost' because possible IPv6
                     httpPort: 0,


### PR DESCRIPTION
This fixes the CLI script so starting via npx works.
This also adds the '-l, --log-level LEVEL' CLI option.

Also add opts.logLevel to MockOtlpServer to simplify making it quiet for testing