### PR TITLE
feat(opentelemetry-node): publish a Docker image to be used with the OTel Operator for k8s

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,20 @@
 # Release a tagged version of the '@elastic/opentelemetry-node' package.
 name: release
 
+# Primarily this workflow is about doing a release for a *tag*. However, this is
+# also run for pushes to "main" to (a) go through some of the motions for
+# testing, and (b) publishing the Docker image with an "edge" label.
 on:
   push:
     tags:
       - v*.*.*
+    branches:
+      - main
 
 # 'id-token' perm needed for npm publishing with provenance (see
 # https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)
 permissions:
+  attestations: write
   contents: write
   pull-requests: read
   id-token: write
@@ -16,6 +22,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE_NAME: docker.elastic.co/observability/elastic-otel-node
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,16 +34,61 @@ jobs:
           node-version: 'v18.20.2'
           registry-url: 'https://registry.npmjs.org'
 
+      # Setup a Docker "buildx" builder container, used by "build-push-action"
+      # below for multi-platform image builds. Notes on multi-platform images:
+      # https://github.com/elastic/apm-agent-nodejs/issues/4038#issuecomment-2130406402
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Elastic Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
+          username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
+          password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
+
       - run: npm run ci-all
 
-      - name: npm publish
+      - name: Extract metadata (tags, labels)
+        id: docker-meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          tags: |
+            # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
+            type=semver,pattern={{version}}
+            # "edge" Docker tag on git push to default branch
+            type=edge
+
+      - name: Build and Push Docker Image
+        id: docker-push
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85  # v6.7.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: 'packages/opentelemetry-node/Dockerfile'
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
+
+      - name: Attest Docker image
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c  # v1.4.3
+        with:
+          subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
+          subject-digest: ${{ steps.docker-push.outputs.digest }}
+          push-to-registry: true
+
+      - name: npm publish (only for tag releases)
+        if: startsWith(github.ref, 'refs/tags')
         working-directory: ./packages/opentelemetry-node
         run: npm publish
         env:
           # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: GitHub release
+      - name: GitHub release (only for tag releases)
+        if: startsWith(github.ref, 'refs/tags')
         run: ./scripts/github-release.sh "packages/opentelemetry-node" "${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
             type=semver,pattern={{version}}
             # "edge" Docker tag on git push to default branch
             type=edge
+          labels: |
+            org.opencontainers.image.vendor=Elastic
+            org.opencontainers.image.title=elastic-otel-node
+            org.opencontainers.image.description=Elastic Distribution of OpenTelemetry Node.js
 
       - name: Build and Push Docker Image
         id: docker-push

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ notes. For structured developer and contributing *rules and guidelines*, see
 [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 
-### mockotlpserver OTLP endpoint
+# mockotlpserver OTLP endpoint
 
 For local development, it can be useful to have an OTLP endpoint that is local,
 and can show the exact details of data being sent by the OTel SDK. The
@@ -60,8 +60,6 @@ See [the mockotlpserver README](./packages/mockotlpserver#readme) for more detai
 
 # Logging tips
 
-## logging
-
 `OTEL_LOG_LEVEL=verbose` will turn on the most verbose-level logging in the SDK,
 including enabling the core OpenTelemetry `diag` logger messages.
 
@@ -83,3 +81,84 @@ environment variables:
     NODE_DEBUG=*
     NODE_DEBUG_NATIVE=*
 
+
+# Testing k8s auto-instrumentation with OTel Operator
+
+This section briefly shows how to locally test the EDOT Node.js Docker image
+(docker.elastic.co/observability/elastic-otel-node), with the OpenTelemetry
+Operator for Kubernetes. The goal is to deploy a Node.js app to a k8s cluster
+and have it auto-instrumented without needing to touch the app -- other than
+adding a label to its k8s deployment YAML.
+
+```bash
+# Create a local k8s cluster (using KinD), if you don't have one to use.
+cd packages/mockotlpserver/share/k8s
+./create-kind-cluster-with-registry.sh
+# Check that is working via:
+#     kubectl cluster-info --context kind-kind
+#     docker ps
+
+# Install OTel Operator (and its dependency cert-manager).
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.1/cert-manager.yaml
+sleep 10 # Installing the operator immediately after has failed for me.
+kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
+
+# Build and deploy a 'mockotlpserver' that we'll use to collect OTel data.
+# If you already have an OTLP collection endpoint (e.g. an Elastic cloud
+# deployment), you can skip this step.
+cd ../../
+docker build -t localhost:5001/mockotlpserver .
+docker push localhost:5001/mockotlpserver
+cd share/k8s
+kubectl apply -f ./mockotlpserver-service.yaml
+kubectl apply -f ./mockotlpserver-deployment.yaml
+# Check that is working via:
+#     kubectl logs service/mockotlpserver  # includes "OTLP/HTTP listening ..."
+#     kubectl get all
+
+# Build the elastic-otel-node image.
+cd ../../../../packages/opentelemetry-node
+docker build -t localhost:5001/elastic-otel-node -f ./Dockerfile ../../
+docker push localhost:5001/elastic-otel-node
+
+cd ../../examples/otel-operator
+
+# Create an OTel "Instrumentation", a CRD defined by the OTel Operator, that
+# will instrument Node.js apps, exporting telemetry to
+# `http://mockotlpserver:4318`, where our mock OTLP server from above is
+# listening. (If you used a different OTLP endpoint, then you will need to tweak
+# "instrumentation.yaml").
+kubectl apply -f ./instrumentation.yaml
+# TODO: deal with the "Warning: sampler type not set" here.
+
+# Build and deploy a simple Node.js app (an Express-based HTTP server).
+docker build -t localhost:5001/myapp .
+docker push localhost:5001/myapp
+kubectl apply -f ./deployment.yaml
+```
+
+The `deployment.yaml` for the example "myapp" includes a `livenessProbe`, so the
+app will be called periodically. This means we expect to see some tracing data
+for `GET /ping` calls.
+
+```bash
+kubectl logs -f service/mockotlpserver
+```
+
+If things are working you will see trace (and metric) data being received by the
+OTLP endpoint. For example:
+
+```
+------ trace f5a770 (4 spans) ------
+       span d0df8d "GET /ping" (2.8ms, SPAN_KIND_SERVER, GET http://10.244.0.10:3000/ping -> 200)
+  +1ms `- span 6a85d1 "middleware - query" (0.1ms, SPAN_KIND_INTERNAL)
+  +0ms `- span 2bc334 "middleware - expressInit" (0.1ms, SPAN_KIND_INTERNAL)
+  +0ms `- span a739b1 "request handler - /ping" (0.0ms, SPAN_KIND_INTERNAL)
+```
+
+Clean up, when done playing:
+
+```bash
+kind delete cluster --name=kind
+docker kill kind-registry
+```

--- a/examples/otel-operator/Dockerfile
+++ b/examples/otel-operator/Dockerfile
@@ -1,0 +1,11 @@
+# Vanilla usage in Docker:
+#    docker build -t myapp .
+#    docker run --rm -it -p 3000:3000 myapp
+#    curl -i http://127.0.0.1:3000/ping
+FROM node:18-alpine
+RUN mkdir /app
+WORKDIR /app
+COPY app.js package.json ./
+RUN npm install
+EXPOSE 3000
+CMD ["node", "app.js"]

--- a/examples/otel-operator/README.md
+++ b/examples/otel-operator/README.md
@@ -1,0 +1,1 @@
+TODO: add README content here. For now see ../../DEVELOPMENT.md notes.

--- a/examples/otel-operator/app.js
+++ b/examples/otel-operator/app.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// A simple Express app with a `GET /ping` endpoint.
+
+const express = require('express');
+
+const app = express();
+app.get('/ping', function ping(req, res, next) {
+    console.log('[%s] server /ping', new Date().toISOString());
+    res.send('pong');
+});
+app.use(function onError(err, _req, res, _next) {
+    res.status(500);
+    res.send(`internal error: ${err.message}`);
+});
+
+const server = app.listen(3000, '0.0.0.0', () => {
+    console.log('Listening on', server.address());
+});
+
+// Call this local server after a couple seconds so we have trace data from
+// at least one request.
+setTimeout(async () => {
+    await fetch('http://127.0.0.1:3000/ping');
+}, 2000);

--- a/examples/otel-operator/deployment.yaml
+++ b/examples/otel-operator/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      annotations:
+        # This annotation is what tells the OTel Operator "Instrumentation"
+        # to auto-instrument this application.
+        instrumentation.opentelemetry.io/inject-nodejs: "true"
+      labels:
+        app: myapp
+    spec:
+      containers:
+      - name: myapp
+        image: localhost:5001/myapp
+        ports:
+        - containerPort: 3000
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 3000
+          initialDelaySeconds: 1
+          periodSeconds: 10

--- a/examples/otel-operator/instrumentation.yaml
+++ b/examples/otel-operator/instrumentation.yaml
@@ -1,0 +1,20 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: my-otel-instrumentation
+spec:
+  exporter:
+    # gRPC (used by default by opentelemetry-operator/autoinstrumentation-nodejs)
+    #endpoint: http://mockotlpserver:4317
+    # HTTP/proto (used by default by EDOT)
+    endpoint: http://mockotlpserver:4318
+  nodejs:
+    #image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.52.1
+    #image: docker.elastic.co/observability/elastic-otel-node
+    image: localhost:5001/elastic-otel-node
+    env:
+      - name: OTEL_LOG_LEVEL
+        value: debug
+      # Note: For OTLP endpoints that require auth, you will want an env entry
+      # for `OTEL_EXPORTER_OTLP_HEADERS="Authorization=..."` or similar.
+

--- a/examples/otel-operator/package.json
+++ b/examples/otel-operator/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app-manual-instr",
+  "version": "1.0.0",
+  "private": true,
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/packages/opentelemetry-node/Dockerfile
+++ b/packages/opentelemetry-node/Dockerfile
@@ -1,0 +1,46 @@
+# This builds a Docker image including the Elastic Distribution of OpenTelemetry
+# for Node.js (EDOT Node.js). This is typically published as:
+#
+#   docker.elastic.co/observability/elastic-otel-node:<TAG>
+#
+# The image is effectively the `@elastic/opentelemetry-node` npm package, with
+# its dependencies, and a "autoinstrumentation.js" driver, as required by the
+# OpenTelemetry Operator.
+#
+# To build this image, do the equivalent of the following. The build context is
+# the *top* of the repo, because some build scripts outside of the package
+# dir are required:
+#   cd packages/opentelemetry-node
+#   docker build -t <name>:<tag> -f ./Dockerfile ../../
+#
+# Typically the build is handled by CI, which also adds other build tags,
+# handles provenance, etc.
+
+FROM node:22 AS build
+
+WORKDIR /build/src
+COPY ./packages/opentelemetry-node/ /build/src/packages/opentelemetry-node/
+COPY ./scripts/ /build/src/scripts/
+
+WORKDIR /build/pack
+# Use 'npm pack' to get just the npm-published files.
+RUN npm --loglevel=warn pack /build/src/packages/opentelemetry-node
+RUN tar --strip-components=1 -xf elastic-opentelemetry-node-*.tgz
+RUN rm elastic-opentelemetry-node-*.tgz
+# Add the lock file, so we can 'npm ci'.
+RUN cp /build/src/packages/opentelemetry-node/package-lock.json .
+RUN npm ci --omit=dev --ignore-scripts
+# Add license notice info for bundled dependencies.
+RUN /build/src/scripts/gen-notice.sh . > ./NOTICE2.md \
+    && mv NOTICE2.md NOTICE.md
+COPY /build/src/packages/opentelemetry-node/autoinstrumentation.js ./
+
+# The OpenTelemetry Operator support for Node.js instrumentation requires:
+# 1. all files under "/autoinstrumentation",
+# 2. a working `cp` in the image for copying that directory to a shared volume,
+# 3. a "autoinstrumentation.js" in that dir (will be used with `--require ...`).
+#
+# See notes at: https://github.com/open-telemetry/opentelemetry-operator/blob/main/autoinstrumentation/nodejs/Dockerfile
+FROM docker.elastic.co/wolfi/chainguard-base
+COPY --from=build /build/pack /autoinstrumentation
+RUN chmod -R go+r /autoinstrumentation

--- a/packages/opentelemetry-node/Dockerfile
+++ b/packages/opentelemetry-node/Dockerfile
@@ -28,12 +28,12 @@ RUN npm --loglevel=warn pack /build/src/packages/opentelemetry-node
 RUN tar --strip-components=1 -xf elastic-opentelemetry-node-*.tgz
 RUN rm elastic-opentelemetry-node-*.tgz
 # Add the lock file, so we can 'npm ci'.
-RUN cp /build/src/packages/opentelemetry-node/package-lock.json .
+RUN cp /build/src/packages/opentelemetry-node/package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts
 # Add license notice info for bundled dependencies.
 RUN /build/src/scripts/gen-notice.sh . > ./NOTICE2.md \
     && mv NOTICE2.md NOTICE.md
-COPY /build/src/packages/opentelemetry-node/autoinstrumentation.js ./
+RUN cp /build/src/packages/opentelemetry-node/autoinstrumentation.js ./
 
 # The OpenTelemetry Operator support for Node.js instrumentation requires:
 # 1. all files under "/autoinstrumentation",

--- a/packages/opentelemetry-node/autoinstrumentation.js
+++ b/packages/opentelemetry-node/autoinstrumentation.js
@@ -17,8 +17,10 @@
  * under the License.
  */
 
-// XXX *not* included in npm published files, used for OTel operator
+// This file is included in the elastic-otel-node Docker image. It is used by
+// the OpenTeleemtry Operator for Kubernetes to support auto-instrumentation of
+// Node.js applications. The OTel Operator sets the following envvar for
+// Node.js apps to setup the OpenTelemetry SDK:
+//      --require .../autoinstrumentation.js
 
-console.log('XXX autoinstrumentation.js: start');
 require('./require.js');
-console.log('XXX autoinstrumentation.js: end');

--- a/packages/opentelemetry-node/autoinstrumentation.js
+++ b/packages/opentelemetry-node/autoinstrumentation.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// XXX *not* included in npm published files, used for OTel operator
+
+console.log('XXX autoinstrumentation.js: start');
+require('./require.js');
+console.log('XXX autoinstrumentation.js: end');

--- a/scripts/gen-notice.sh
+++ b/scripts/gen-notice.sh
@@ -37,7 +37,6 @@ function fatal {
 
 # ---- mainline
 
-TOP=$(cd $(dirname $0)/../ >/dev/null; pwd)
 if [[ "$1" == "--lint" ]]; then
     LINT_MODE=true
     OUTFILE=/dev/null
@@ -134,4 +133,4 @@ npm ls --omit=dev --all --parseable \
                 }
             })
         })
-    ' >$OUTFILE
+    ' >>$OUTFILE


### PR DESCRIPTION
This adds publishing of a docker.elastic.co/observability/elastic-otel-node
Docker image that can be used with the OpenTelemetry Operator to support
auto-instrumentation of Node.js apps in Kubernetes containers. The image
is a build of EDOT Node.js.

Refs: https://github.com/elastic/elastic-otel-node/issues/255

# checklist

So far this is just the build/code changes required: no docs, tests, etc. Some of the following may be moved to a separate PR.

- [x] add some docs, perhaps an "examples/..." dir showing its usage
- [ ] testing (though testing may be easier by first merging this PR to get an "edge"-labelled image published to play around with
- [ ] manual testing: tracing, metrics, logs. ESM?
