### PR TITLE
github-action: use elastic/oblt-actions/github/is-member-of

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,10 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - id: is_elastic_member
-      uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
+      uses: elastic/oblt-actions/github/is-member-of@v1
       with:
-        username: ${{ github.actor }}
-        token: ${{ secrets.APM_TECH_USER_TOKEN }}
+        github-org: "elastic"
+        github-user: ${{ github.actor }}
+        github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
 
     - name: Add community and triage labels
       if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'elastic-renovate-prod[bot]'


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been deprecated in favor of 
https://github.com/elastic/oblt-actions.

Requires https://github.com/elastic/oblt-actions/pull/135 to be merged.

If there are any questions, please reach out to the @elastic/observablt-ci
