### PR TITLE
chore: flail to attempt to fix dependabot updates for examples/ dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,7 +68,7 @@ updates:
     reviewers:
       - "elastic/apm-agent-node-js"
     groups:
-      examples:
+      the-examples:
         patterns:
         - "*"
 


### PR DESCRIPTION
Dependabot updates of the examples dir has been warning recently with:

    updater | 2024/09/30 01:28:04 WARN <job_892539850> Please check your configuration as there are groups where no dependencies match:
    - examples

    This can happen if:
    - the group's 'pattern' rules are misspelled
    - your configuration's 'allow' rules do not permit any of the dependencies that match the group
    - the dependencies that match the group rules have been removed from your project
