### PR TITLE
chore: flail (take 2) to attempt to fix dependabot updates for examples/ dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,10 +67,6 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "elastic/apm-agent-node-js"
-    groups:
-      the-examples:
-        patterns:
-        - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This time we'll remove the grouping to see if that helps.
We would *like* dependabot updates for examples/ to all be in a single group,
but that isn't working, so we'll take separate update PRs instead if that works.

Refs: #384 (flail attempt 1)
