### PR TITLE
chore: flail (take 3) to attempt to fix dependabot updates for examples/ dir

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {},
+  "// Would prefer this devDep, but dependabot isn't updating: @elastic/opentelemetry-node": "../packages/opentelemetry-node",
   "devDependencies": {
-    "@elastic/opentelemetry-node": "../packages/opentelemetry-node",
+    "@elastic/opentelemetry-node": "*",
     "bunyan": "^1.8.15",
     "express": "^4.19.2"
   },


### PR DESCRIPTION
This time we'll remove the relative dep, on the theory that it is
tripping up dependabot. Keeping it this way puts a burden on the
developer that wants to test exapmles with local changes. Perhaps that
is fine for now. Arguably though this is the tail wagging the dog.

Refs: #384 (flail attempt 1)
Refs: #386 (flail attempt 2)
