### PR TITLE
release @elastic/opentelemetry-node@0.4.1

### DIFF
--- a/.github/workflows/release-mockotlpserver.yml
+++ b/.github/workflows/release-mockotlpserver.yml
@@ -26,8 +26,6 @@ jobs:
           node-version: 'v18.20.4'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm run ci-all
-
       - name: npm publish
         working-directory: ./packages/mockotlpserver
         run: npm publish
@@ -36,7 +34,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: GitHub release
-        run: ./scripts/github-release.sh "packages/mockotlpserver" "${{ github.ref_name }}"
+        run: |
+          npm ci  # need top-level devDeps for github-release.sh script
+          ./scripts/github-release.sh "packages/mockotlpserver" "${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,9 @@ jobs:
 
       - name: GitHub release (only for tag releases)
         if: startsWith(github.ref, 'refs/tags')
-        run: ./scripts/github-release.sh "packages/opentelemetry-node" "${{ github.ref_name }}"
+        run: |
+          npm ci  # need top-level devDeps for github-release.sh script
+          ./scripts/github-release.sh "packages/opentelemetry-node" "${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@
 all:
 	npm run ci-all
 
+.PHONY: clean
+clean:
+	npm run clean-all
+
 .PHONY: lint
 lint:
 	npm run lint

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "ci-all": "set -e; ls -d . packages/* examples | while read d; do (cd $d; echo; echo \"> $d\"; npm ci); done",
-    "clean-all": "ls -d . packages/* examples | while read d; do (cd $d; echo \"> $d\"; rm -rf node_modules); done",
+    "ci-all": "./scripts/oneach.sh npm ci",
+    "clean-all": "set -e; rm -rf build; ./scripts/oneach.sh rm -rf node_modules",
     "oneach": "./scripts/oneach.sh",
     "lint": "npm run lint:eslint && ls -d packages/* | while read d; do (cd $d; npm run lint); done",
     "lint:eslint": "eslint --ext=js,mjs,cjs scripts examples # requires node >=16.0.0",

--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @elastic/opentelemetry-node Changelog
 
+## v0.4.1
+
+- chore: Fix release workflow. v0.4.0 was released without a GitHub releases
+  entry.
+
 ## v0.4.0
 
 - feat: A Docker image is now being published that can be used with the

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-node",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.53.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "commonjs",
   "description": "Elastic Distribution of OpenTelemetry Node.js",
   "publishConfig": {


### PR DESCRIPTION
The 0.4.0 release workflow failed to create the GitHub release entry (the last step):

https://github.com/elastic/elastic-otel-node/actions/runs/11149243541/job/30987681502
```
 ./scripts/github-release.sh: line 46: /home/runner/work/elastic-otel-node/elastic-otel-node/node_modules/.bin/json: No such file or directory
Error: Process completed with exit code 127.
```

This change fixes the release workflow and bumps to v0.4.1 for a new release.
(This also adds the `make clean` convenience and improves the ci-all and clean-all npm scripts.)