### PR TITLE
release @elastic/opentelemetry-node@0.5.0

### DIFF
--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @elastic/opentelemetry-node Changelog
 
+## v0.5.0
+
+- chore: Bump `@opentelemetry/*` dependencies (#419, #411, #403)
+
 ## v0.4.1
 
 - chore: Fix release workflow. v0.4.0 was released without a GitHub releases

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-node",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.54.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "commonjs",
   "description": "Elastic Distribution of OpenTelemetry Node.js",
   "publishConfig": {


### PR DESCRIPTION
A regular release to include a few bumps of otel deps.
