### PR TITLE
fix(mockotlpserver): be explicit about what under db/ to include in published package

### DIFF
--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -39,7 +39,7 @@
   "files": [
     "lib",
     "opentelemetry",
-    "db",
+    "db/README.md",
     "ui"
   ],
   "main": "lib/index.js",


### PR DESCRIPTION
This avoids accidentally publishing any db/trace-*.ndjson files that might
be kicking around in that directory from usage of the mock server.
