### PR TITLE
release instrumentation-openai 0.4.0

### DIFF
--- a/.github/workflows/release-instrumentation-openai.yml
+++ b/.github/workflows/release-instrumentation-openai.yml
@@ -29,6 +29,12 @@ jobs:
           node-version: 'v18.20.4'
           registry-url: 'https://registry.npmjs.org'
 
+      - run: npm ci
+        working-directory: ${{ env.PKGDIR }}
+
+      - run: npm run compile
+        working-directory: ${{ env.PKGDIR }}
+
       - run: npm publish
         working-directory: ${{ env.PKGDIR }}
         env:

--- a/packages/instrumentation-openai/CHANGELOG.md
+++ b/packages/instrumentation-openai/CHANGELOG.md
@@ -1,6 +1,12 @@
 # @elastic/opentelemetry-instrumentation-openai Changelog
 
+## v0.4.0
+
+- Fix the release workflow.
+
 ## v0.3.0
+
+(Broken release. Use v0.4.0 or later.)
 
 - Based on GenAI semantic conventions 1.29.
 - Instrumentation of chat completion, including streaming and tool calls.

--- a/packages/instrumentation-openai/package-lock.json
+++ b/packages/instrumentation-openai/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-instrumentation-openai",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-instrumentation-openai",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "^0.56.0",

--- a/packages/instrumentation-openai/package.json
+++ b/packages/instrumentation-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-instrumentation-openai",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "OpenTelemetry instrumentation for the `openai` OpenAI client library",
   "type": "commonjs",
   "publishConfig": {


### PR DESCRIPTION
Fix the release workflow to install deps and compile before published,
otherwise a mostly empty package is published.
