### PR TITLE
chore(mockotlpserver): update protos to v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "oneach": "./scripts/oneach.sh",
     "lint": "npm run lint:eslint && ls -d packages/* | while read d; do (cd $d; npm run lint); done",
     "lint:eslint": "eslint --ext=js,mjs,cjs scripts examples # requires node >=16.0.0",
-    "lint:fix": "eslint --ext=js,mjs,cjs .eslintrc.js scripts examples --fix && ls -d packages/* | while read d; do (cd $d; npm run lint:fix); done",
-    "maint:update-protos": "node scripts/update-protos.js"
+    "lint:fix": "eslint --ext=js,mjs,cjs .eslintrc.js scripts examples --fix && ls -d packages/* | while read d; do (cd $d; npm run lint:fix); done"
   },
   "devDependencies": {
     "@types/node": "^22.9.3",

--- a/packages/mockotlpserver/lib/types-proto.d.ts
+++ b/packages/mockotlpserver/lib/types-proto.d.ts
@@ -3819,15 +3819,6 @@ export namespace opentelemetry {
                     /** HistogramDataPoint max. */
                     public max?: (number|null);
 
-                    /** HistogramDataPoint _sum. */
-                    public _sum?: "sum";
-
-                    /** HistogramDataPoint _min. */
-                    public _min?: "min";
-
-                    /** HistogramDataPoint _max. */
-                    public _max?: "max";
-
                     /**
                      * Creates a new HistogramDataPoint instance using the specified properties.
                      * @param [properties] Properties to set
@@ -4002,15 +3993,6 @@ export namespace opentelemetry {
 
                     /** ExponentialHistogramDataPoint zeroThreshold. */
                     public zeroThreshold?: (number|null);
-
-                    /** ExponentialHistogramDataPoint _sum. */
-                    public _sum?: "sum";
-
-                    /** ExponentialHistogramDataPoint _min. */
-                    public _min?: "min";
-
-                    /** ExponentialHistogramDataPoint _max. */
-                    public _max?: "max";
 
                     /**
                      * Creates a new ExponentialHistogramDataPoint instance using the specified properties.

--- a/packages/mockotlpserver/opentelemetry/proto/collector/README.md
+++ b/packages/mockotlpserver/opentelemetry/proto/collector/README.md
@@ -11,7 +11,7 @@ This package describes the OpenTelemetry collector protocol.
 
 ### NOTE from Elastic Observability
 The contents of these `.proto` files have been extracted from the repository
-https://github.com/open-telemetry/opentelemetry-proto.git at the following tag/hash v1.3.2.
+https://github.com/open-telemetry/opentelemetry-proto.git at the following tag/hash v1.4.0.
 
 This will be kept in sync wth the version being used in opentelemetry-js repository
 https://github.com/open-telemetry/opentelemetry-js.git

--- a/packages/mockotlpserver/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/packages/mockotlpserver/opentelemetry/proto/metrics/v1/metrics.proto
@@ -29,6 +29,24 @@ option go_package = "go.opentelemetry.io/proto/otlp/metrics/v1";
 // storage, OR can be embedded by other protocols that transfer OTLP metrics
 // data but do not implement the OTLP protocol.
 //
+// MetricsData
+// └─── ResourceMetrics
+//   ├── Resource
+//   ├── SchemaURL
+//   └── ScopeMetrics
+//      ├── Scope
+//      ├── SchemaURL
+//      └── Metric
+//         ├── Name
+//         ├── Description
+//         ├── Unit
+//         └── data
+//            ├── Gauge
+//            ├── Sum
+//            ├── Histogram
+//            ├── ExponentialHistogram
+//            └── Summary
+//
 // The main difference between this message and collector protocol is that
 // in this message there will not be any "control" or "metadata" specific to
 // OTLP protocol.
@@ -85,7 +103,6 @@ message ScopeMetrics {
 //
 //   https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md
 //
-//
 // The data model and relation between entities is shown in the
 // diagram below. Here, "DataPoint" is the term used to refer to any
 // one of the specific data point value types, and "points" is the term used
@@ -97,7 +114,7 @@ message ScopeMetrics {
 // - DataPoint contains timestamps, attributes, and one of the possible value type
 //   fields.
 //
-//     Metric
+//    Metric
 //  +------------+
 //  |name        |
 //  |description |
@@ -251,6 +268,9 @@ message ExponentialHistogram {
 // data type. These data points cannot always be merged in a meaningful way.
 // While they can be useful in some applications, histogram data points are
 // recommended for new applications.
+// Summary metrics do not have an aggregation temporality field. This is
+// because the count and sum fields of a SummaryDataPoint are assumed to be
+// cumulative values.
 message Summary {
   repeated SummaryDataPoint data_points = 1;
 }
@@ -589,7 +609,8 @@ message ExponentialHistogramDataPoint {
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the
-// time-varying values of a Summary metric.
+// time-varying values of a Summary metric. The count and sum fields represent
+// cumulative values.
 message SummaryDataPoint {
   reserved 1;
 

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -35,7 +35,8 @@
     "start": "node lib/cli.js",
     "watch": "node --watch lib/cli.js",
     "example": "cd ../../examples && pwd && node -r @elastic/opentelemetry-node simple-http-request.js",
-    "example3": "cd ../../examples && for flav in http/protobuf http/json grpc; do OTEL_EXPORTER_OTLP_PROTOCOL=$flav node -r @elastic/opentelemetry-node simple-http-request.js; done"
+    "example3": "cd ../../examples && for flav in http/protobuf http/json grpc; do OTEL_EXPORTER_OTLP_PROTOCOL=$flav node -r @elastic/opentelemetry-node simple-http-request.js; done",
+    "maint:update-protos": "node scripts/update-protos.js"
   },
   "files": [
     "lib",

--- a/packages/mockotlpserver/scripts/update-protos.js
+++ b/packages/mockotlpserver/scripts/update-protos.js
@@ -44,10 +44,12 @@ const {
 const {resolve, relative, join, sep} = require('path');
 const {tmpdir} = require('os');
 
+const TOP = resolve(__dirname, '..');
+
 // SCRIPT PARAMS
 const REPO_NAME = 'opentelemetry-proto';
 const REPO_URL = `https://github.com/open-telemetry/${REPO_NAME}.git`;
-const HASH_TAG = 'v1.3.2';
+const HASH_TAG = 'v1.4.0';
 
 // HELPER FUNCTIONS
 /**
@@ -81,13 +83,7 @@ execSync(`git clone --depth 1 --branch ${HASH_TAG} ${REPO_URL}`, {
 });
 
 // 2nd copy files into the right place
-const targetPath = resolve(
-    __dirname,
-    '..',
-    'packages',
-    'mockotlpserver',
-    'opentelemetry'
-);
+const targetPath = resolve(TOP, 'opentelemetry');
 if (existsSync(targetPath)) {
     rmSync(targetPath, {recursive: true, force: true});
 }
@@ -130,8 +126,7 @@ https://github.com/open-telemetry/opentelemetry-js.git
 appendFileSync(readmePath, appendText, {encoding: 'utf-8'});
 
 // 5th - generate types using protobufjs-cli from the source path
-const rootPath = resolve(__dirname, '..');
-const binPath = join(rootPath, 'node_modules', '.bin');
+const binPath = join(TOP, 'node_modules', '.bin');
 const protosPath = resolve(sourcePath, 'proto');
 const protos = [
     '/collector/trace/v1/trace_service.proto',
@@ -153,7 +148,7 @@ const generateCommand = [
     '|',
     // Then generate types
     join(binPath, 'pbts'),
-    `-o ${rootPath}/packages/mockotlpserver/lib/types-proto.d.ts`,
+    `-o ${TOP}/lib/types-proto.d.ts`,
     `-`,
 ].join(' ');
 


### PR DESCRIPTION
This also moves the script for updating the protos from the
top-level into the mockotlpserver package dir.

The v1.4.0 update was basically all profiles, so no update
effectively for us.
