### PR TITLE
fix(mockotlpserver): return a valid response to http/protobuf requests

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -7,6 +7,9 @@
     - Bold "span", "event", "$metricType" in renderings, and style the name of that
       span/event/metric in magenta. See PR for screenshots.
 - fix: Don't throw printing a metrics summary for a histogram without attributes.
+- fix: Return a valid response to http/protobuf requests. Before this a picky exporter
+  could complain about the invalid response data.
+  (https://github.com/elastic/elastic-otel-node/issues/477)
 
 ## v0.5.0
 


### PR DESCRIPTION
Fixes: #477

---

Before this we were returning `{"ok": 1}` (i.e. JSON) as the response body to a http/protobuf request and I think recent changes in OTel JS's exporter was complaining about it. Responding with an empty body seems to suffice.