### PR TITLE
release mockotlpserver 0.6.0

### DIFF
--- a/.github/workflows/release-mockotlpserver.yml
+++ b/.github/workflows/release-mockotlpserver.yml
@@ -9,6 +9,7 @@ on:
 # 'id-token' perm needed for npm publishing with provenance (see
 # https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)
 permissions:
+  attestations: write
   contents: write
   pull-requests: read
   id-token: write
@@ -19,6 +20,7 @@ jobs:
     env:
       PKGDIR: packages/mockotlpserver
       PKGNAME: "@elastic/mockotlpserver"
+      DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository }}/mockotlpserver
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,6 +30,43 @@ jobs:
         with:
           node-version: 'v18.20.4'
           registry-url: 'https://registry.npmjs.org'
+
+      # Push a Docker image.
+      - uses: docker/setup-buildx-action@v3
+      - id: docker-meta
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96  # v5.6.1
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          tags: |
+            # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
+            type=semver,pattern={{version}}
+          labels: |
+            org.opencontainers.image.vendor=Elastic
+            org.opencontainers.image.title=mockotlpserver
+            org.opencontainers.image.description=A mock OTLP server, for dev and testing
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        id: docker-push
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355  # v6.10.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: 'packages/mockotlpserver/Dockerfile'
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
+      - name: Attest Docker image
+        uses: actions/attest-build-provenance@c4fbc648846ca6f503a13a2281a5e7b98aa57202  # v2.0.1
+        with:
+          subject-name: ${{ env.DOCKER_IMAGE_NAME }}
+          subject-digest: ${{ steps.docker-push.outputs.digest }}
+          push-to-registry: true
 
       - run: npm publish
         working-directory: ${{ env.PKGDIR }}

--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -1,12 +1,13 @@
 # @elastic/mockotlpserver Changelog
 
-## Unreleased
+## v0.6.0
 
-- feat: Some improvements to "summary" styling.
+- feat: Some improvements to "summary" styling. (https://github.com/elastic/elastic-otel-node/pull/459)
     - Show attributes for histogram metrics and handle showing multiple data points.
     - Bold "span", "event", "$metricType" in renderings, and style the name of that
       span/event/metric in magenta. See PR for screenshots.
-- fix: Don't throw printing a metrics summary for a histogram without attributes.
+- fix: Don't throw when printing a metrics summary for a histogram without attributes.
+  (https://github.com/elastic/elastic-otel-node/pull/375)
 - fix: Return a valid response to http/protobuf requests. Before this a picky exporter
   could complain about the invalid response data.
   (https://github.com/elastic/elastic-otel-node/issues/477)

--- a/packages/mockotlpserver/lib/http.js
+++ b/packages/mockotlpserver/lib/http.js
@@ -49,7 +49,11 @@ function diagChFromReqUrl(reqUrl) {
 }
 
 // helper functions
-function badRequest(res, errMsg='Invalid or no data received', errCode=400) {
+function badRequest(
+    res,
+    errMsg = 'Invalid or no data received',
+    errCode = 400
+) {
     res.writeHead(400);
     res.end(
         JSON.stringify({
@@ -133,7 +137,10 @@ class HttpService extends Service {
         this._server = http.createServer((req, res) => {
             const contentType = req.headers['content-type'];
             if (!parsersMap[contentType]) {
-                return badRequest(res, `unexpected request Content-Type: "${contentType}"`)
+                return badRequest(
+                    res,
+                    `unexpected request Content-Type: "${contentType}"`
+                );
             }
 
             const chunks = [];
@@ -154,7 +161,7 @@ class HttpService extends Service {
                 let resBody = null;
                 if (contentType === 'application/json') {
                     resBody = JSON.stringify({
-                        ok: 1
+                        ok: 1,
                     });
                 }
                 res.writeHead(200);

--- a/packages/mockotlpserver/package-lock.json
+++ b/packages/mockotlpserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/mockotlpserver",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.11.1",

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "commonjs",
   "description": "A mock OTLP server, useful for dev and testing",
   "publishConfig": {

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -45,3 +45,14 @@ if [[ -z "$(cat $BUILD_DIR/release-notes1.md)" ]]; then
 fi
 echo "## Changelog" >$BUILD_DIR/release-notes.md
 cat $BUILD_DIR/release-notes1.md >>$BUILD_DIR/release-notes.md
+
+# Add a release notes footer.
+BRANCH=$(git -C "$TOP" symbolic-ref HEAD | cut -d/ -f 3-)
+DIRECTORY=$($JSON -f "$PKG_DIR/package.json" repository.directory)
+README_URL="https://github.com/elastic/elastic-otel-node/tree/$BRANCH/$DIRECTORY#readme"
+CHANGELOG_URL="https://github.com/elastic/elastic-otel-node/blob/$BRANCH/$DIRECTORY/CHANGELOG.md"
+echo "BRANCH is: $BRANCH"
+echo "
+---
+
+[README]($README_URL) | [Full Changelog]($CHANGELOG_URL)" >>$BUILD_DIR/release-notes.md

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -51,7 +51,6 @@ BRANCH=$(git -C "$TOP" symbolic-ref HEAD | cut -d/ -f 3-)
 DIRECTORY=$($JSON -f "$PKG_DIR/package.json" repository.directory)
 README_URL="https://github.com/elastic/elastic-otel-node/tree/$BRANCH/$DIRECTORY#readme"
 CHANGELOG_URL="https://github.com/elastic/elastic-otel-node/blob/$BRANCH/$DIRECTORY/CHANGELOG.md"
-echo "BRANCH is: $BRANCH"
 echo "
 ---
 

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -47,7 +47,7 @@ echo "## Changelog" >$BUILD_DIR/release-notes.md
 cat $BUILD_DIR/release-notes1.md >>$BUILD_DIR/release-notes.md
 
 # Add a release notes footer.
-BRANCH=$(git -C "$TOP" symbolic-ref HEAD | cut -d/ -f 3-)
+BRANCH=$((git -C "$TOP" symbolic-ref HEAD 2>/dev/null || echo "refs/heads/main") | cut -d/ -f 3-)
 DIRECTORY=$($JSON -f "$PKG_DIR/package.json" repository.directory)
 README_URL="https://github.com/elastic/elastic-otel-node/tree/$BRANCH/$DIRECTORY#readme"
 CHANGELOG_URL="https://github.com/elastic/elastic-otel-node/blob/$BRANCH/$DIRECTORY/CHANGELOG.md"


### PR DESCRIPTION
This bumps mockotlpserver to v0.6.0 for release.
It also tweaks the notes added to GitHub releases from this
repo to include links to the package README and changelog.
It also adds build/push of a mockotlpserver Docker image
during release:
  ghcr.io/elastic/elastic-otel-node/mockotlpserver

Closes: #467
