### PR TITLE
release @elastic/opentelemetry-node@0.6.0

### DIFF
--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/opentelemetry-node Changelog
 
-## Unreleased
+## v0.6.0
 
 - feat: Add `@elastic/opentelemetry-instrumentation-openai` to the default set
   of instrumentations. See <https://github.com/elastic/elastic-otel-node/tree/main/packages/instrumentation-openai#readme>

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-node",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/opentelemetry-instrumentation-openai": "^0.4.0",
+        "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "1.27.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.56.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.56.0",
@@ -70,7 +71,6 @@
         "@grpc/grpc-js": "^1.11.1",
         "@grpc/proto-loader": "^0.7.13",
         "@hapi/hapi": "^21.3.10",
-        "@opentelemetry/api": "^1.3.0",
         "@types/tape": "^5.6.4",
         "bunyan": "^1.8.15",
         "dotenv": "^16.4.5",

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@elastic/opentelemetry-instrumentation-openai": "^0.4.0",
+        "@elastic/opentelemetry-instrumentation-openai": "^0.4.1",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "1.27.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.56.0",
@@ -95,7 +95,7 @@
     },
     "../mockotlpserver": {
       "name": "@elastic/mockotlpserver",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1615,10 +1615,9 @@
       "link": true
     },
     "node_modules/@elastic/opentelemetry-instrumentation-openai": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@elastic/opentelemetry-instrumentation-openai/-/opentelemetry-instrumentation-openai-0.4.0.tgz",
-      "integrity": "sha512-o9lxtoozYqW4yP9WP8DL7HVb1buy5GAE/mCRN5AXDuVWPflENFOfBnbgyS3wI/9TXDk6oIBEtAw/cwJYsiPQaA==",
-      "license": "Apache-2.0",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@elastic/opentelemetry-instrumentation-openai/-/opentelemetry-instrumentation-openai-0.4.1.tgz",
+      "integrity": "sha512-icMzDpw3SvHy5SObWF02MMFFvjUWQsifoPOfDOWDbviiLuKoeFTWCzVpit7F7Bc77qkcMFXCXg0K/D8m0vSnlg==",
       "dependencies": {
         "@opentelemetry/api-logs": "^0.56.0",
         "@opentelemetry/instrumentation": "^0.56.0",
@@ -10234,9 +10233,9 @@
       }
     },
     "@elastic/opentelemetry-instrumentation-openai": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@elastic/opentelemetry-instrumentation-openai/-/opentelemetry-instrumentation-openai-0.4.0.tgz",
-      "integrity": "sha512-o9lxtoozYqW4yP9WP8DL7HVb1buy5GAE/mCRN5AXDuVWPflENFOfBnbgyS3wI/9TXDk6oIBEtAw/cwJYsiPQaA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@elastic/opentelemetry-instrumentation-openai/-/opentelemetry-instrumentation-openai-0.4.1.tgz",
+      "integrity": "sha512-icMzDpw3SvHy5SObWF02MMFFvjUWQsifoPOfDOWDbviiLuKoeFTWCzVpit7F7Bc77qkcMFXCXg0K/D8m0vSnlg==",
       "requires": {
         "@opentelemetry/api-logs": "^0.56.0",
         "@opentelemetry/instrumentation": "^0.56.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -67,7 +67,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@elastic/opentelemetry-instrumentation-openai": "^0.4.0",
+    "@elastic/opentelemetry-instrumentation-openai": "^0.4.1",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/core": "1.27.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.56.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "commonjs",
   "description": "Elastic Distribution of OpenTelemetry Node.js",
   "publishConfig": {

--- a/scripts/gen-notice.sh
+++ b/scripts/gen-notice.sh
@@ -84,9 +84,6 @@ npm ls --omit=dev --all --parseable \
             "pg-types": "license.pg-types.txt",
             "undici-types": "license.undici.txt",
             "tr46": "license.MIT.txt",
-            // Temporary manual license path for v0.4.0 of @elastic/opentelemetry-instrumentation-openai
-            // TODO: remove this when the next version is published and updated in EDOT Node.js.
-            "@elastic/opentelemetry-instrumentation-openai": "../packages/instrumentation-openai/LICENSE",
         }
         const allowNoLicFile = [
             "binary-search" // CC is a public domain dedication, no need for license text.


### PR DESCRIPTION
This adds an instrumentation for the 'openai' client
library: `@elastic/opentelemetry-instrumentation-openai`.
