### PR TITLE
release mockotlpserver 0.6.1

### DIFF
--- a/.github/workflows/release-mockotlpserver.yml
+++ b/.github/workflows/release-mockotlpserver.yml
@@ -40,8 +40,8 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
-            type=semver,pattern={{version}}
+            # git tag "mockotlpserver-v1.2.3" -> Docker tags "1.2.3", "latest"
+            type=match,pattern=mockotlpserver-v(\d+\.\d+\.\d+),group=1
           labels: |
             org.opencontainers.image.vendor=Elastic
             org.opencontainers.image.title=mockotlpserver

--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @elastic/mockotlpserver Changelog
 
+## v0.6.1
+
+- Fix Docker publishing.
+
 ## v0.6.0
 
 - feat: Some improvements to "summary" styling. (https://github.com/elastic/elastic-otel-node/pull/459)

--- a/packages/mockotlpserver/package-lock.json
+++ b/packages/mockotlpserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/mockotlpserver",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.11.1",

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "commonjs",
   "description": "A mock OTLP server, useful for dev and testing",
   "publishConfig": {


### PR DESCRIPTION
Fix Docker publishing. The handling for getting a Docker tag
from the git tag was broken because of the mockotlpserver-
prefix.
