### PR TITLE
fix Docker build in CI; release mockotlpserver 0.6.2

### DIFF
--- a/.github/workflows/release-mockotlpserver.yml
+++ b/.github/workflows/release-mockotlpserver.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   attestations: write
   contents: write
+  packages: write
   pull-requests: read
   id-token: write
 
@@ -55,7 +56,7 @@ jobs:
         id: docker-push
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355  # v6.10.0
         with:
-          context: .
+          context: ${{ env.PKGDIR }}
           platforms: linux/amd64,linux/arm64
           file: 'packages/mockotlpserver/Dockerfile'
           push: true

--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -1,8 +1,12 @@
 # @elastic/mockotlpserver Changelog
 
+## v0.6.2
+
+- Fix Docker publishing (permissions, context dir).
+
 ## v0.6.1
 
-- Fix Docker publishing.
+- Fix Docker publishing (git tag -> docker image tag handling).
 
 ## v0.6.0
 

--- a/packages/mockotlpserver/package-lock.json
+++ b/packages/mockotlpserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/mockotlpserver",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.11.1",

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "commonjs",
   "description": "A mock OTLP server, useful for dev and testing",
   "publishConfig": {


### PR DESCRIPTION
Fix another couple issues with Docker build/push in CI.
This fixes a failure seen here: https://github.com/elastic/elastic-otel-node/actions/runs/12382422883
Also add the requisite token permission for pushing a package to ghcr.io.