### PR TITLE
release instrumentation-openai 0.4.1

### DIFF
--- a/packages/instrumentation-openai/CHANGELOG.md
+++ b/packages/instrumentation-openai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @elastic/opentelemetry-instrumentation-openai Changelog
 
+## v0.4.1
+
+- Include "LICENSE" file in the published package.
+
 ## v0.4.0
 
 - Fix the release workflow.

--- a/packages/instrumentation-openai/package-lock.json
+++ b/packages/instrumentation-openai/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-instrumentation-openai",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-instrumentation-openai",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "^0.56.0",

--- a/packages/instrumentation-openai/package.json
+++ b/packages/instrumentation-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-instrumentation-openai",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OpenTelemetry instrumentation for the `openai` OpenAI client library",
   "type": "commonjs",
   "publishConfig": {

--- a/scripts/gen-notice.sh
+++ b/scripts/gen-notice.sh
@@ -84,9 +84,6 @@ npm ls --omit=dev --all --parseable \
             "pg-types": "license.pg-types.txt",
             "undici-types": "license.undici.txt",
             "tr46": "license.MIT.txt",
-            // Temporary manual license path for v0.4.0 of @elastic/opentelemetry-instrumentation-openai
-            // TODO: remove this when the next version is published and updated in EDOT Node.js.
-            "@elastic/opentelemetry-instrumentation-openai": "../packages/instrumentation-openai/LICENSE",
         }
         const allowNoLicFile = [
             "binary-search" // CC is a public domain dedication, no need for license text.

--- a/scripts/gen-notice.sh
+++ b/scripts/gen-notice.sh
@@ -84,6 +84,9 @@ npm ls --omit=dev --all --parseable \
             "pg-types": "license.pg-types.txt",
             "undici-types": "license.undici.txt",
             "tr46": "license.MIT.txt",
+            // Temporary manual license path for v0.4.0 of @elastic/opentelemetry-instrumentation-openai
+            // TODO: remove this when the next version is published and updated in EDOT Node.js.
+            "@elastic/opentelemetry-instrumentation-openai": "../packages/instrumentation-openai/LICENSE",
         }
         const allowNoLicFile = [
             "binary-search" // CC is a public domain dedication, no need for license text.


### PR DESCRIPTION
A release with the LICENSE file included fixes an issue with
building the *EDOT* Docker image, because the in-'docker build'
run of scripts/gen-notice.sh no longer needs to dig into
'packages/instrumentation-openai/...' to find its license file
text.

---

Here is an example of the EDOT Node.js build failure while building its Docker image:
https://github.com/elastic/elastic-otel-node/actions/runs/12382883805

The issue is that it runs gen-notice.sh in the Docker build context,
but a recent workaround comment fixed `gen-notice.sh` to get
the instr-openai/LICENSE from the source tree. That fails in the
Docker build context. Either we copy that "packages/instrumentation-openai/LICENSE"
into the Docker build context, or we (a) get a new instr-openai release
with a license file, and (b) update EDOT Node.js to use it.
I choose the latter.

﻿