### PR TITLE
chore: Slack notifications for issue/PR open/close actions

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -48,7 +48,7 @@ jobs:
           DRAFT_GRAY = '#6a737d'
 
           ctx = json.loads(os.environ["GITHUB_CONTEXT"])
-          pprint(ctx) // debug dump for now
+          pprint(ctx) # debug dump for now
           event = ctx["event"]
           action = event["action"]
           if "issue" in event:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,0 +1,118 @@
+# Post a slack message something like the following for issue and PR actions:
+#     <$url|$title>
+#     | $repo#$num · issue opened by $user
+#
+# Configuration:
+# 1. Set `SLACK_CHANNEL`.
+# 2. Add a `SLACK_BOT_TOKEN` secret to your repo. This is the "Bot User OAuth
+#    Token" from the "OAuth & Permissions" section of your Slack App
+#    (https://api.slack.com/apps). The token must have the `chat:write`
+#    permission.
+# 3. Optionally tweak the `if:` and `on:` sections below to control which issue
+#    and PR events are skipped.
+
+name: slack
+
+env:
+  SLACK_CHANNEL: "#apm-agent-node"
+
+on:
+  issues:
+    types: [opened, reopened, closed]
+  pull_request:
+    types: [opened, ready_for_review, reopened, closed]
+
+jobs:
+  slack:
+    # Skip notification if:
+    # - dependabot PRs, too noisy
+    # - draft PRs
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' || !(github.event.action == 'opened' && github.event.pull_request.draft) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare Slack message
+        id: prepare
+        shell: python
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          import os
+          from pprint import pprint
+          import json
+          from html import escape
+
+          CLOSED_RED = '#cb2431'
+          GITHUB_BLACK = '#24292f'
+          MERGED_PURPLE = '#6f42c1'
+          OPEN_GREEN = '#36a64f'
+          DRAFT_GRAY = '#6a737d'
+
+          ctx = json.loads(os.environ["GITHUB_CONTEXT"])
+          pprint(ctx) // debug dump for now
+          event = ctx["event"]
+          action = event["action"]
+          if "issue" in event:
+            title = event["issue"]["title"]
+            url = event["issue"]["html_url"]
+            num = event["issue"]["number"]
+            action_str = f"issue {action}"
+            color = {
+              "opened": OPEN_GREEN,
+              "reopened": OPEN_GREEN,
+              "closed": CLOSED_RED,
+            }.get(action, "#ffffff")
+          elif "pull_request" in event:
+            title = event["pull_request"]["title"]
+            url = event["pull_request"]["html_url"]
+            num = event["pull_request"]["number"]
+            if action == "closed":
+              if event["pull_request"]["merged"]:
+                action_str = "PR merged"
+                color = MERGED_PURPLE
+              else:
+                action_str = "PR closed"
+                color = CLOSED_RED
+            elif event["pull_request"]["draft"]:
+              action_str = "PR in draft"
+              color = DRAFT_GRAY
+            elif action == "ready_for_review":
+              action_str = "PR ready for review"
+              color = OPEN_GREEN
+            elif:
+              action_str = "PR opened"
+              color = OPEN_GREEN
+          else:
+            pprint(ctx)
+            raise ValueError('unexpected event: not an issue or PR event')
+
+          # Use https://app.slack.com/block-kit-builder to play with styling.
+          payload = {
+            "channel": os.environ["SLACK_CHANNEL"],
+            "text": f"<{url}|{escape(title)}>", # escape angle-brackets
+            "attachments": [
+              {
+                "color": color,
+                "blocks": [
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "mrkdwn",
+                        "text": f"{ctx['repository']}#{num} · *{action_str}* by {event['sender']['login']}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+
+          with open(os.environ.get("GITHUB_OUTPUT"), "a") as f:
+            f.write("payload={}".format(json.dumps(payload)))
+
+      - name: Post Slack message
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: ${{ steps.prepare.outputs.payload }}

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -27,7 +27,9 @@ jobs:
     # Skip notification if:
     # - dependabot PRs, too noisy
     # - draft PRs
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' || !(github.event.action == 'opened' && github.event.pull_request.draft) }}
+    if: ${{ !(github.event.action == 'opened' && github.event.pull_request.draft) ||
+      github.event.pull_request.user.login != 'dependabot[bot]' ||
+      github.event.pull_request.user.login != 'elastic-renovate-prod[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Prepare Slack message
@@ -39,7 +41,6 @@ jobs:
           import os
           from pprint import pprint
           import json
-          from html import escape
 
           CLOSED_RED = '#cb2431'
           GITHUB_BLACK = '#24292f'
@@ -48,7 +49,7 @@ jobs:
           DRAFT_GRAY = '#6a737d'
 
           ctx = json.loads(os.environ["GITHUB_CONTEXT"])
-          pprint(ctx) # debug dump for now
+          # pprint(ctx) # for dev/debugging
           event = ctx["event"]
           action = event["action"]
           if "issue" in event:
@@ -78,21 +79,46 @@ jobs:
             elif action == "ready_for_review":
               action_str = "PR ready for review"
               color = OPEN_GREEN
-            elif:
+            else:
               action_str = "PR opened"
               color = OPEN_GREEN
           else:
             pprint(ctx)
             raise ValueError('unexpected event: not an issue or PR event')
 
+          def gfm2slack(text):
+            """Limited conversion of the subset of GitHub Flavor Markdown (gfm)
+            supported in GitHub issue/PR titles to a safe string for a Slack
+            link. https://api.slack.com/reference/surfaces/formatting"""
+            # Escape angle brackets to allow usage in Slack link.
+            text = text.replace('<', '&lt;')
+            text = text.replace('>', '&gt;')
+            # TODO: How to escape asterisk bolding and underscore italicizing?
+            return text
+
           # Use https://app.slack.com/block-kit-builder to play with styling.
           payload = {
             "channel": os.environ["SLACK_CHANNEL"],
-            "text": f"<{url}|{escape(title)}>", # escape angle-brackets
+            # Note: Omitting the "text" field is intentional, so that it is not
+            # rendered by default. Guidelines on accessibility in:
+            #   https://api.slack.com/methods/chat.postMessage#text-blocks-attachments
+            # are unclear for "attachments" usage. This competes with:
+            #   https://api.slack.com/reference/messaging/attachments#guidelines__message-attachments-as-objects
+            # guidelines to group all object data inside the attachment.
+            # The downside is that the `chatMessage` below results in warnings
+            # from the Slack API about not including the top-level "text".
+            #"text": f"<{url}|{gfm2slack(title)}>",
             "attachments": [
               {
                 "color": color,
                 "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": f"<{url}|{gfm2slack(title)}>"
+                    }
+                  },
                   {
                     "type": "context",
                     "elements": [


### PR DESCRIPTION
# the issue

The typical way to get notifications in Slack for various actions in a GitHub repo is via https://github.com/integrations/slack, the GitHub-maintained integration for Slack.

This integration has the following issues with its notifications for GitHub issue and PR actions:

- It is over-wordy, resulting in notification noise masking any other conversation in the channel. This lowers the signal-to-noise ratio in the channel, which discourages meaningful conversation.
    - It includes some body content from issues/PRs. This may be a nice idea for a repo with commonly simple and short issue/PR descriptions. However, in practice (IMHO) it is rarely enough to avoid the need to visit the full issue in the browser to meaningfully understand and interact with the issue/PR. It can also get silly for PRs that have large `<details>` blocks, which the Slack rendering doesn't hide. E.g. https://github.com/elastic/opbeans-node/pull/304
    - It includes some issue metadata, sometimes some chat-ops buttons ("Comment", "Close").
    - It includes a **variable-height** summary of actions/checks on PRs. This sounds nice, but it results in dynamic-height content in the chat area that is distracting for ongoing conversation.
- In the wordiness the (small, gray) text with the *repo* name is hard to find. We have these notifications for 4+ repos, so it is pain to have to hunt for that.
- It `@-`names people listed as reviewers for PRs and makes a *Slack thread* for every PR to show when it is merged. This sounds like a nice idea, but in practice means that the "Threads" section of Slack is spammed with useless unread threads for merged PRs that I've reviewed.
- Basically the Slack integration is trying to be a fancy chat-ops thingy, and I don't want the noise. I want higher conversational signal.
- It doesn't support ignoring some PR categories: specifically ignoring dependabot/renovate PRs. Currently we have those scheduled for Sunday.  Every Monday morning is a multi-page scroll of useless notifications about regular dependabot maintenance work. It is very easy to lose *meaningful* conversation from Friday or over the weekend in that noise.


If the integration supported ignoring PRs from dependabot, renovate, and possibly other automation, that likely would have sufficed. There are a dozen or so issues requesting something like this (https://github.com/integrations/slack/issues?q=is%3Aissue+dependabot), the main one being [this one](https://github.com/integrations/slack/issues/951), and even two PRs implementing it (https://github.com/integrations/slack/pull/974, https://github.com/integrations/slack/pull/1252). However, since that first one, GitHub removed the source code from the repo to use a closed source implementation and does not accept PRs.

# first attempt: Slack App watching GitHub repo events API

Initially I started implementing a Slack app, using Slack's [Bolt](https://api.slack.com/bolt) framework for building Slack apps.  This app would replace the issue and PR functionality of GitHub's Slack integration.  It would listen to [GitHub repository events](https://docs.github.com/en/rest/activity/events?apiVersion=2022-11-28#list-repository-events) for each subscribed repo and send appropriate messages to the Slack channel.

The main reasons I gave up on this approach are:

1. The [GitHub repository events API](https://docs.github.com/en/rest/activity/events?apiVersion=2022-11-28#list-repository-events) says:

    > This API is not built to serve real-time use cases. Depending on the time of day, event latency can be anywhere from 30s to 6h.

    While this Slack notifications app need not be *real-time*, somewhat timely would be nice. Having 30s-6h delays on notifications isn't appealing. I suspect in practice the latency is typically fine. (I have a total guess that using an internal-to-GitHub message queue, rather than the public GitHub REST API, is a reason GitHub moved the integration implementation to be closed source.)

2. The complexity of running a persistent service for these notifications was not appealing to me. I'd have to get into deploying this (with secrets) somewhere. A goal of this hack was to simplify. I didn't want to add oncall/maintenance work for myself.


# second attempt: GH Action in each repo

https://github.com/integrations/slack/issues/951#issuecomment-1631482308 proposed a comparatively simple workaround: add a GitHub Action to the repo you want to watch that sends a notification to Slack.

Basically I riffed on that idea, playing with the notification style/layout and using `shell: python` to better cope with encoding issues.

![Screenshot 2025-01-07 at 4 13 15 PM](https://github.com/user-attachments/assets/d9333411-8f48-4232-be90-1c7e4750e107)

![Screenshot 2025-01-07 at 5 01 42 PM](https://github.com/user-attachments/assets/d114234f-8d13-4fb1-82a0-992b307451f4)


# proposal

- [x] Discuss this. (David and I discussed today.)
- [ ] Try this out in elastic/elastic-otel-node and elastic/apm-agent-nodejs. 
- [ ] Then if we prefer it, stop the **issue and PR** notifications from the existing GitHub+Slack integration, via `/github subscribe owner/repo releases deployments`.
    - We can keep its notifications for some other things like [unfurling links](https://api.slack.com/reference/messaging/link-unfurling#slack_app_unfurling) to GH issues/comments/code-ranges).
    - I believe the command to do this is: `/github subscribe owner/repo releases deployments`. This keeps the default `releases` and `deployments` feature. It drops `issues`, `pulls`, and `commits` (we require all commits to shipping branches to go through a PR, so showing commits is a somewhat redundant).
- [ ] And then we do this for the other repos we care about.