### PR TITLE
chore(ci): change from ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   categorize-issues-and-prs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Get token
       id: get_token

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release-instrumentation-openai.yml
+++ b/.github/workflows/release-instrumentation-openai.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       PKGDIR: packages/instrumentation-openai
       PKGNAME: "@elastic/opentelemetry-instrumentation-openai"

--- a/.github/workflows/release-mockotlpserver.yml
+++ b/.github/workflows/release-mockotlpserver.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       PKGDIR: packages/mockotlpserver
       PKGNAME: "@elastic/mockotlpserver"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       DOCKER_IMAGE_NAME: docker.elastic.co/observability/elastic-otel-node
     steps:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ !(github.event.action == 'opened' && github.event.pull_request.draft) ||
       github.event.pull_request.user.login != 'dependabot[bot]' ||
       github.event.pull_request.user.login != 'elastic-renovate-prod[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Prepare Slack message
         id: prepare

--- a/.github/workflows/test-edot.yml
+++ b/.github/workflows/test-edot.yml
@@ -41,7 +41,7 @@ jobs:
           - '14'
           - '14.18.0'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     services:
       redis:

--- a/.github/workflows/test-instrumentation-openai.yml
+++ b/.github/workflows/test-instrumentation-openai.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -48,7 +48,7 @@ jobs:
   # This runs the unit tests against a number of 'openai' versions in the
   # supported range.
   test-all-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -62,7 +62,7 @@ jobs:
       working-directory: packages/instrumentation-openai
 
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     services:
       ollama:
         # A light fork of Ollama to float some in-progress contributions related


### PR DESCRIPTION
This is (a) to avoid the GH Actions warnings in workflow runs, e.g.:

    ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636

and (b) to try it out ahead of the switch.
