### PR TITLE
chore(instr-openai): lock package-lock file version to v3

### DIFF
--- a/packages/instrumentation-openai/.npmrc
+++ b/packages/instrumentation-openai/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=3


### PR DESCRIPTION
This is the default lockfileVersion used npm v9 and later. Node v18,
our min-supported Node.js version, includes npm v10.

Setting this config should ensure that dependabot updates don't
revert the lockfileVersion back to 2.

---

An example of that dependabot switching back to version 2 is here: https://github.com/elastic/elastic-otel-node/pull/543/files#diff-9d4a71f54ee443bf35be8c8af1bea61586971a4b0eca5d2d2be9262804de42e0R4