### PR TITLE
fix(mockotlpserver): fix an alignment issue in trace-summary gutter with 1-char units

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @elastic/mockotlpserver Changelog
 
+## unreleased
+
+- Fix an alignment issue in the "gutter" of the trace-summary (waterfall) output
+  when 1-char units are used (i.e. any time unit above "ms").
+
 ## v0.6.2
 
 - Fix Docker publishing (permissions, context dir).

--- a/packages/mockotlpserver/lib/waterfall.js
+++ b/packages/mockotlpserver/lib/waterfall.js
@@ -100,7 +100,9 @@ function renderSpan(span, prefix = '') {
             unit = 'd';
         }
         gutter = `${sign}${Math.floor(startOffset)}`;
-        gutter = `${' '.repeat(4 - gutter.length)}${gutter}${unit}`;
+        gutter = `${' '.repeat(4 - gutter.length)}${gutter}${unit}${' '.repeat(
+            2 - unit.length
+        )}`;
     } else {
         gutter = ' '.repeat(6);
     }


### PR DESCRIPTION
Before:

```
------ trace 43670f (3 spans) ------
       span 7dc366 "Test Parent" (2007.4ms, SPAN_KIND_INTERNAL)
  +1ms `- span f84ec1 "Test Child 1" (1003.2ms, SPAN_KIND_INTERNAL)
  +1s `- span 534247 "Test Child 2" (1002.1ms, SPAN_KIND_INTERNAL)
```

After:

```
------ trace 43670f (3 spans) ------
       span 7dc366 "Test Parent" (2007.4ms, SPAN_KIND_INTERNAL)
  +1ms `- span f84ec1 "Test Child 1" (1003.2ms, SPAN_KIND_INTERNAL)
  +1s  `- span 534247 "Test Child 2" (1002.1ms, SPAN_KIND_INTERNAL)
```
