### PR TITLE
test(edot): temporarily disable instr-elastic-openai.test.js

### DIFF
--- a/.github/workflows/test-edot.yml
+++ b/.github/workflows/test-edot.yml
@@ -101,7 +101,7 @@ jobs:
       ollama:
         # A light fork of Ollama to float some in-progress contributions related
         # to more closely matching OpenAI behavior.
-        image: ghcr.io/elastic/ollama/ollama:testing
+        image: ollama/ollama:0.5.7
         ports:
           - 11434:11434
 

--- a/.github/workflows/test-edot.yml
+++ b/.github/workflows/test-edot.yml
@@ -98,12 +98,14 @@ jobs:
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: 1
 
-      ollama:
-        # A light fork of Ollama to float some in-progress contributions related
-        # to more closely matching OpenAI behavior.
-        image: ollama/ollama:0.5.7
-        ports:
-          - 11434:11434
+      # Disabled until https://github.com/ollama/ollama/issues/8400 is resolved.
+      # ollama:
+      #   # A light fork of Ollama to float some in-progress contributions related
+      #   # to more closely matching OpenAI behavior.
+      #   image: ghcr.io/elastic/ollama/ollama:testing
+      #   # image: ollama/ollama:0.5.7
+      #   ports:
+      #     - 11434:11434
 
       postgres:
         image: postgres:16

--- a/packages/opentelemetry-node/test/instr-elastic-openai.test.js
+++ b/packages/opentelemetry-node/test/instr-elastic-openai.test.js
@@ -20,20 +20,24 @@
 const http = require('http');
 const {basename} = require('path');
 const test = require('tape');
-const semver = require('semver');
+// const semver = require('semver');
 const {runTestFixtures, assertDeepMatch} = require('./testutils');
 
-let skip = process.env.TEST_GENAI_MODEL === undefined;
-if (skip) {
-    console.log(
-        '# SKIP elastic openai tests: TEST_GENAI_MODEL is not set (load env from test/test-services.env)'
-    );
-} else {
-    skip = !semver.satisfies(process.version, '>=18');
-    if (skip) {
-        console.log('# SKIP elastic openai requires node >=18');
-    }
-}
+let skip = true;
+console.log(
+    '# SKIP elastic/instr-openai test until https://github.com/ollama/ollama/issues/8400 is resolved'
+);
+// let skip = process.env.TEST_GENAI_MODEL === undefined;
+// if (skip) {
+//     console.log(
+//         '# SKIP elastic openai tests: TEST_GENAI_MODEL is not set (load env from test/test-services.env)'
+//     );
+// } else {
+//     skip = !semver.satisfies(process.version, '>=18');
+//     if (skip) {
+//         console.log('# SKIP elastic openai requires node >=18');
+//     }
+// }
 
 /** @type {import('./testutils').TestFixture[]} */
 const testFixtures = [

--- a/packages/opentelemetry-node/test/instr-elastic-openai.test.js
+++ b/packages/opentelemetry-node/test/instr-elastic-openai.test.js
@@ -114,14 +114,20 @@ async function testModelIsPulled() {
                 // be: `{"status":"success"}`.  Otherwise, typically the last
                 // line indicates the error.
                 const chunks = [];
-                res.on('data', (chunk) => { chunks.push(chunk); });
+                res.on('data', (chunk) => {
+                    chunks.push(chunk);
+                });
                 res.on('end', () => {
                     const body = Buffer.concat(chunks).toString('utf8');
                     const lastLine = body.trim().split(/\n/g).slice(-1)[0];
                     if (lastLine === '{"status":"success"}') {
                         resolve();
                     } else {
-                        reject(new Error(`could not pull "${process.env.TEST_GENAI_MODEL}" model: lastLine=${lastLine}`));
+                        reject(
+                            new Error(
+                                `could not pull "${process.env.TEST_GENAI_MODEL}" model: lastLine=${lastLine}`
+                            )
+                        );
                     }
                 });
             }
@@ -140,7 +146,7 @@ test(basename(__filename), {skip}, async (t) => {
         await testModelIsPulled();
         isPulled = true;
         const deltaS = Math.round((new Date() - startTime) / 1000);
-        t.comment(`successfully pulled model (${deltaS}s)`)
+        t.comment(`successfully pulled model (${deltaS}s)`);
     } catch (pullErr) {
         t.error(pullErr);
     }


### PR DESCRIPTION
This temporarily disables the flaky instr-elastic-openai.test.js
until the Ollama crash bug https://github.com/ollama/ollama/issues/8400
is resolved.

As well, this improves the test file's handling for pulling the test
model. Before this the setup code was errorneously assuming the
Ollama response statusCode would indicate success. It doesn't.

Refs: https://github.com/elastic/elastic-otel-node/issues/587
