### PR TITLE
fix(otel-node): fix types for nestjs core instrumentation

### DIFF
--- a/packages/opentelemetry-node/lib/instrumentations.js
+++ b/packages/opentelemetry-node/lib/instrumentations.js
@@ -50,7 +50,7 @@
  *  "@opentelemetry/instrumentation-mongoose": import('@opentelemetry/instrumentation-mongoose').MongooseInstrumentationConfig | InstrumentationFactory,
  *  "@opentelemetry/instrumentation-mysql": import('@opentelemetry/instrumentation-mysql').MySQLInstrumentation | InstrumentationFactory,
  *  "@opentelemetry/instrumentation-mysql2": import('@opentelemetry/instrumentation-mysql2').MySQL2Instrumentation | InstrumentationFactory,
- *  "@opentelemetry/instrumentation-nestjs-core": import('@opentelemetry/instrumentation').InstrumentationConfig | InstrumentationFactory,
+ *  "@opentelemetry/instrumentation-nestjs-core": import('@opentelemetry/instrumentation-nestjs-core').NestInstrumentation | InstrumentationFactory,
  *  "@opentelemetry/instrumentation-net": import('@opentelemetry/instrumentation').InstrumentationConfig | InstrumentationFactory,
  *  "@opentelemetry/instrumentation-pg": import('@opentelemetry/instrumentation-pg').PgInstrumentationConfig | InstrumentationFactory
  *  "@opentelemetry/instrumentation-pino": import('@opentelemetry/instrumentation-pino').PinoInstrumentationConfig | InstrumentationFactory

--- a/packages/opentelemetry-node/types/instrumentations.d.ts
+++ b/packages/opentelemetry-node/types/instrumentations.d.ts
@@ -27,7 +27,7 @@ export type InstrumentaionsMap = {
     "@opentelemetry/instrumentation-mongoose": import('@opentelemetry/instrumentation-mongoose').MongooseInstrumentationConfig | InstrumentationFactory;
     "@opentelemetry/instrumentation-mysql": import('@opentelemetry/instrumentation-mysql').MySQLInstrumentation | InstrumentationFactory;
     "@opentelemetry/instrumentation-mysql2": import('@opentelemetry/instrumentation-mysql2').MySQL2Instrumentation | InstrumentationFactory;
-    "@opentelemetry/instrumentation-nestjs-core": import('@opentelemetry/instrumentation').InstrumentationConfig | InstrumentationFactory;
+    "@opentelemetry/instrumentation-nestjs-core": import('@opentelemetry/instrumentation-nestjs-core').NestInstrumentation | InstrumentationFactory;
     "@opentelemetry/instrumentation-net": import('@opentelemetry/instrumentation').InstrumentationConfig | InstrumentationFactory;
     "@opentelemetry/instrumentation-pg": import('@opentelemetry/instrumentation-pg').PgInstrumentationConfig | InstrumentationFactory;
     "@opentelemetry/instrumentation-pino": import('@opentelemetry/instrumentation-pino').PinoInstrumentationConfig | InstrumentationFactory;


### PR DESCRIPTION
#558 was created to add this instrumentation but it turns out it was already added in https://github.com/elastic/elastic-otel-node/commit/f5a065627dbe179b7d199dd9ad09e87d8bccdd04. This PR just fixes the types of the configurations map.

Adding a test case was considered an tried locally but it is too much effort since it requires to have a specific setup for it (NestJS project, install dependencies, run the project and mockotlpserver at the same time, etc.). `runTestFixtures` is not enough and create something just for 1 instrumentation just feels too much

Closes: #558 