### PR TITLE
feat(otel-node): add fs instrumentation

### DIFF
--- a/packages/opentelemetry-node/docs/supported-technologies.md
+++ b/packages/opentelemetry-node/docs/supported-technologies.md
@@ -42,6 +42,7 @@ requires:
 | `@opentelemetry/instrumentation-cassandra-driver` | `cassandra-driver` version range `>=4.4.0 <5` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-cassandra#readme) |
 | `@opentelemetry/instrumentation-express` | `express` version range `^4.0.0` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#readme) |
 | `@opentelemetry/instrumentation-fastify` | `fastify` version range `>=3 <5` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-fastify#readme) |
+| `@opentelemetry/instrumentation-fs` | `fs` module for Node.js `>=14` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs#readme) |
 | `@opentelemetry/instrumentation-generic-pool` | `generic-pool` version range `2 - 2.3, ^2.4, >=3` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-generic-pool#readme) |
 | `@opentelemetry/instrumentation-graphql` | `graphql` version range `>=14.0.0 <17` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-graphql#readme) |
 | `@opentelemetry/instrumentation-grpc` | `@grpc/grpc-js` version range `^1.0.0` | [README](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc#readme) |

--- a/packages/opentelemetry-node/lib/instrumentations.js
+++ b/packages/opentelemetry-node/lib/instrumentations.js
@@ -287,12 +287,12 @@ function getInstrumentations(opts = {}) {
         let instr;
 
         if (enabledFromEnv) {
-            instrConfig = { ...instrConfig, enabled: true };
+            instrConfig = {...instrConfig, enabled: true};
         } else if (name === '@opentelemetry/instrumentation-fs') {
-            // if `fs` not present in envvar instrumentation is disabled 
+            // if `fs` not present in envvar instrumentation is disabled
             // unless an explicit config says the opposite
             // ref: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2467
-            instrConfig = { enabled: false, ...instrConfig };
+            instrConfig = {enabled: false, ...instrConfig};
         }
 
         if (!instrConfig || instrConfig.enabled !== false) {

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -29,6 +29,7 @@
         "@opentelemetry/instrumentation-dns": "^0.43.0",
         "@opentelemetry/instrumentation-express": "^0.47.0",
         "@opentelemetry/instrumentation-fastify": "^0.44.0",
+        "@opentelemetry/instrumentation-fs": "^0.19.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.43.0",
         "@opentelemetry/instrumentation-graphql": "^0.47.0",
         "@opentelemetry/instrumentation-grpc": "^0.57.1",
@@ -2700,6 +2701,21 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.57.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.0.tgz",
+      "integrity": "sha512-JGwmHhBkRT2G/BYNV1aGI+bBjJu4fJUD/5/Jat0EWZa2ftrLV3YE8z84Fiij/wK32oMZ88eS8DI4ecLGZhpqsQ==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0"
       },
       "engines": {
         "node": ">=14"
@@ -11717,6 +11733,15 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.57.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-fs": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.0.tgz",
+      "integrity": "sha512-JGwmHhBkRT2G/BYNV1aGI+bBjJu4fJUD/5/Jat0EWZa2ftrLV3YE8z84Fiij/wK32oMZ88eS8DI4ecLGZhpqsQ==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0"
       }
     },
     "@opentelemetry/instrumentation-generic-pool": {

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -85,6 +85,7 @@
     "@opentelemetry/instrumentation-dns": "^0.43.0",
     "@opentelemetry/instrumentation-express": "^0.47.0",
     "@opentelemetry/instrumentation-fastify": "^0.44.0",
+    "@opentelemetry/instrumentation-fs": "^0.19.0",
     "@opentelemetry/instrumentation-generic-pool": "^0.43.0",
     "@opentelemetry/instrumentation-graphql": "^0.47.0",
     "@opentelemetry/instrumentation-grpc": "^0.57.1",

--- a/packages/opentelemetry-node/test/fixtures/use-fs.js
+++ b/packages/opentelemetry-node/test/fixtures/use-fs.js
@@ -32,8 +32,8 @@ async function main() {
             } else {
                 resolve(st);
             }
-        })
-    })
+        });
+    });
 }
 
 const tracer = trace.getTracer('test');

--- a/packages/opentelemetry-node/test/fixtures/use-fs.js
+++ b/packages/opentelemetry-node/test/fixtures/use-fs.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Usage: node -r @elastic/opentelemetry-node use-fs.js
+
+const {stat} = require('fs');
+const {trace} = require('@opentelemetry/api');
+
+const path = `${__dirname}/use-fs.js`;
+
+async function main() {
+    await new Promise((resolve, reject) => {
+        stat(path, (err, st) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(st);
+            }
+        })
+    })
+}
+
+const tracer = trace.getTracer('test');
+tracer.startActiveSpan('manual-span', async (span) => {
+    await main();
+    span.end();
+});

--- a/packages/opentelemetry-node/test/instr-fs.test.js
+++ b/packages/opentelemetry-node/test/instr-fs.test.js
@@ -70,7 +70,12 @@ const testFixtures = [
             const spans = col.sortedSpans;
             t.equal(spans.length, 18);
 
-            t.strictEqual(spans.filter((s) => s.scope.name === '@opentelemetry/instrumentation-fs').length, 17);
+            t.strictEqual(
+                spans.filter(
+                    (s) => s.scope.name === '@opentelemetry/instrumentation-fs'
+                ).length,
+                17
+            );
             t.ok(spans.every((s) => s.kind === 'SPAN_KIND_INTERNAL'));
         },
     },

--- a/packages/opentelemetry-node/test/instr-fs.test.js
+++ b/packages/opentelemetry-node/test/instr-fs.test.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Test that 'express' instrumentation generates the telemetry we expect.
+
+const test = require('tape');
+const {runTestFixtures} = require('./testutils');
+
+/** @type {import('./testutils').TestFixture[]} */
+const testFixtures = [
+    {
+        name: 'use-fs (default disabled)',
+        args: ['./fixtures/use-fs.js'],
+        cwd: __dirname,
+        env: {
+            NODE_OPTIONS: '--require=@elastic/opentelemetry-node',
+        },
+        // verbose: true,
+        checkTelemetry: (t, col) => {
+            // We expect spans like this
+            // ------ trace 6dc0c7 (2 spans) ------
+            //        span 3d5f2a "manual-span" (1.2ms, SPAN_KIND_INTERNAL)
+            const spans = col.sortedSpans;
+            t.equal(spans.length, 1);
+
+            t.equal(spans[0].name, 'manual-span');
+            t.equal(spans[0].kind, 'SPAN_KIND_INTERNAL');
+        },
+    },
+    {
+        name: 'use-fs (enabled via env var)',
+        args: ['./fixtures/use-fs.js'],
+        cwd: __dirname,
+        env: {
+            NODE_OPTIONS: '--require=@elastic/opentelemetry-node',
+            OTEL_NODE_ENABLED_INSTRUMENTATIONS: 'fs',
+        },
+        // verbose: true,
+        checkTelemetry: (t, col) => {
+            // We expect spans like this
+            // ------ trace 7c87d0 (1 span) ------
+            //        span 1ecc98 "fs statSync" (0.0ms, SPAN_KIND_INTERNAL)
+            // ------ trace 281967 (1 span) ------
+            //        span 7bab63 "fs statSync" (0.0ms, SPAN_KIND_INTERNAL)
+            // ------ trace 8b214a (1 span) ------
+            //        span 417068 "fs readFileSync" (0.1ms, SPAN_KIND_INTERNAL)
+            // ------ trace d61bc6 (1 span) ------
+            //        span a6f9cc "fs statSync" (0.1ms, SPAN_KIND_INTERNAL)
+            // ------ trace 292114 (2 spans) ------
+            //        span c66b96 "manual-span" (6.6ms, SPAN_KIND_INTERNAL)
+            //   +1ms `- span 5b7d1c "fs stat" (6.3ms, SPAN_KIND_INTERNAL)
+            // ------ trace 96054a (1 span) ------
+            //        span 9dda4d "manual-span" (9.3ms, SPAN_KIND_INTERNAL)
+            const spans = col.sortedSpans;
+            t.equal(spans.length, 18);
+
+            t.strictEqual(spans.filter((s) => s.scope.name === '@opentelemetry/instrumentation-fs').length, 17);
+            t.ok(spans.every((s) => s.kind === 'SPAN_KIND_INTERNAL'));
+        },
+    },
+];
+
+test('fs instrumentation', (suite) => {
+    runTestFixtures(suite, testFixtures);
+    suite.end();
+});


### PR DESCRIPTION
This PR adds `@opentelenetry/instrumentation-fs` and follows the consensus of the OTEL JS SIG on having it disabled by default.
ref: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2453
ref: https://github.com/elastic/elastic-otel-node/issues/240#issuecomment-2644043930

The included tests check for enabling it via environment variable but not via passing a config object in `getInstrumentations` method. 

@trentm let's discuss if test is needed and also where to put in the docs how to enable the instrumentation. 

Closes: #240 