### PR TITLE
release @elastic/opentelemetry-node@0.7.0

### DIFF
--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/opentelemetry-node Changelog
 
-## Unreleased
+## v0.7.0
 
 - BREAKING CHANGE: Bump min-supported node to `^18.19.0 || >=20.6.0`.
   This raises the minimum-supported Node.js to the same as coming releases of OpenTelemetry JS.

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-node",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/opentelemetry-instrumentation-openai": "^0.4.1",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "commonjs",
   "description": "Elastic Distribution of OpenTelemetry Node.js",
   "publishConfig": {


### PR DESCRIPTION
Highlights:

- Bump min-supported node to `^18.19.0 || >=20.6.0`. This *drops support* for Node.js 14 and 16. (#584)
- Better ESM instrumentation bootstrapping. The recommendation for starting EDOT Node.js has changed from using `--require` to using `--import`. E.g.: `node --import @elastic/opentelemetry-node my-app.js`. (#584)
- Add instrumentations: mysql, mysql2, amqplib, cassandra-driver