### PR TITLE
chore(otel-node): use peerDeps for otel/api dep, cap it to a known-supported maximum

### DIFF
--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -7,6 +7,11 @@
   EDOT Node.js for their application.
   (https://github.com/elastic/elastic-otel-node/pull/663)
 
+- chore: Use `peerDependencies` for `@opentelemetry/api` dep, and cap it to a
+  known-supported maximum version, according to [OTel JS guidance for
+  implementors](https://github.com/open-telemetry/opentelemetry-js/issues/4832)
+  (https://github.com/elastic/elastic-otel-node/issues/606)
+
 ## v0.7.0
 
 - BREAKING CHANGE: Bump min-supported node to `^18.19.0 || >=20.6.0`.

--- a/packages/opentelemetry-node/lib/metrics/host.js
+++ b/packages/opentelemetry-node/lib/metrics/host.js
@@ -3,17 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const {metrics} = require('@opentelemetry/api');
 const {AggregationType} = require('@opentelemetry/sdk-metrics');
 const {HostMetrics} = require('@opentelemetry/host-metrics');
 
 /** @type {HostMetrics} */
 let hostMetricsInstance;
 function enableHostMetrics() {
-    hostMetricsInstance = new HostMetrics({
-        // Pass in default meterProvider to avoid a log.warn('No meter provider, using default').
-        meterProvider: metrics.getMeterProvider(),
-    });
+    hostMetricsInstance = new HostMetrics();
     hostMetricsInstance.start();
 }
 

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/opentelemetry-instrumentation-openai": "^0.4.1",
-        "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.200.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.200.0",
@@ -81,6 +80,7 @@
         "@grpc/grpc-js": "^1.11.1",
         "@grpc/proto-loader": "^0.7.13",
         "@hapi/hapi": "^21.3.10",
+        "@opentelemetry/api": ">=1.3.0 <1.10.0",
         "@types/tape": "^5.6.4",
         "amqplib": "^0.10.5",
         "bunyan": "^1.8.15",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "clean": "rm -rf node_modules test/fixtures/a-ts-proj/node_modules",
-    "example": "cd ../../examples && node -r @elastic/opentelemetry-node simple-http-request.js",
+    "example": "cd ../../examples && node --import @elastic/opentelemetry-node simple-http-request.js",
     "lint": "npm run lint:eslint && npm run lint:types && npm run lint:deps && npm run lint:license-files && npm run lint:changelog",
     "lint:eslint": "eslint --ext=js,mjs,cjs . # requires node >=16.0.0",
     "lint:types": "rm -rf build/lint-types && tsc --outDir build/lint-types && diff -ur types build/lint-types",
@@ -64,9 +64,11 @@
     },
     "./package.json": "./package.json"
   },
+  "peerDependency": {
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  },
   "dependencies": {
     "@elastic/opentelemetry-instrumentation-openai": "^0.4.1",
-    "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.200.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.200.0",
@@ -137,6 +139,7 @@
     "@grpc/grpc-js": "^1.11.1",
     "@grpc/proto-loader": "^0.7.13",
     "@hapi/hapi": "^21.3.10",
+    "@opentelemetry/api": ">=1.3.0 <1.10.0",
     "@types/tape": "^5.6.4",
     "amqplib": "^0.10.5",
     "bunyan": "^1.8.15",


### PR DESCRIPTION
Closes: https://github.com/elastic/elastic-otel-node/issues/606
Refs: https://github.com/open-telemetry/opentelemetry-js/issues/4832
