### PR TITLE
dependabot: support for docker internal registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,10 @@
+registries:
+  docker-elastic:
+    type: docker-registry
+    url: https://docker.elastic.co
+    username: ${{secrets.ELASTIC_DOCKER_USERNAME}}
+    password: ${{secrets.ELASTIC_DOCKER_PASSWORD}}
+
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -100,3 +107,11 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    registries: "*"
+    reviewers:
+      - "elastic/apm-agent-node-js"
+    schedule:
+      interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>elastic/renovate-config:only-chainguard"
-  ]
-}


### PR DESCRIPTION
### What

Use `dependabot` for updating docker images stored in our internal docker registry using [this](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot).

### Why

We already have secrets stored for accessing the internal docker registry. Use one dependency management tool with native support for GitHub actions and the [GH secrets access control](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/). 

This has been already tested in the past in a sandbox repository and also in another GH internal repositories.

### Actions

- [x] Create Dependabot GitHub secret using CasC.

### Issues

See https://github.com/elastic/apm-agent-nodejs/pull/4539
