### PR TITLE
feat(mockotlpserver): summary rendering of Sum and Gauge metric types

### DIFF
--- a/packages/mockotlpserver/lib/waterfall.js
+++ b/packages/mockotlpserver/lib/waterfall.js
@@ -223,7 +223,7 @@ class TraceWaterfallPrinter extends Printer {
         // flushed at about the same time.
         setTimeout(() => {
             console.log(rendering.join('\n'));
-        }, 10);
+        }, 50);
     }
 }
 


### PR DESCRIPTION
For example, when using this to compare (I'm setting `TEMPORALITY_PREFERENCE=delta` here because the PR to do that by default isn't in yet):

```
cd examples
OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta node --import @elastic/opentelemetry-node simple-http-request.js
```

### Before

<img width="902" alt="Screenshot 2025-03-28 at 11 34 01 AM" src="https://github.com/user-attachments/assets/6afd941d-11f6-40fc-ba7a-f73f4beec3e6" />

### After

![Screenshot 2025-03-28 at 11 34 37 AM](https://github.com/user-attachments/assets/683f3312-4e18-4a23-8ef8-274638b26354)


Pros:
- can meaningfully see this metric data in the "summary" output

Cons:
- Much taller output with the default metrics coming from EDOT Node.js... so things aren't as compact.


Still I think it is obviously better. If one doesn't care to look at metrics in mockotlpserver summary output, then one can:

```
npx mockotlpserver -o inspect,trace-summary,logs-summary   # i.e. exclude 'metrics-summary'
```