### PR TITLE
release instrumentation-openai 0.5.0

### DIFF
--- a/packages/instrumentation-openai/CHANGELOG.md
+++ b/packages/instrumentation-openai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @elastic/opentelemetry-instrumentation-openai Changelog
 
+## v0.5.0
+
+- Update to [OpenTelemetry JS SDK 2.0](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md).
+
 ## v0.4.1
 
 - Include "LICENSE" file in the published package.

--- a/packages/instrumentation-openai/package.json
+++ b/packages/instrumentation-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-instrumentation-openai",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "OpenTelemetry instrumentation for the `openai` OpenAI client library",
   "type": "commonjs",
   "publishConfig": {
@@ -24,7 +24,7 @@
   ],
   "author": "Elastic Observability <https://www.elastic.co/observability>",
   "engines": {
-    "node": ">=18"
+    "node": "^18.19.0 || >=20.6.0"
   },
   "scripts": {
     "clean": "rm -rf node_modules build",


### PR DESCRIPTION
# checklist

- [ ] wait for https://github.com/elastic/elastic-otel-node/pull/690 and update mockotlpserver dev-dep in package-lock first. Don't *need* to wait for this update, however.