### PR TITLE
feat(opentelemetry-node)!: ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING=false to default to *no* log-sending for log framework instrumentations

### DIFF
--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 ## Unreleased
 
-- feat: Set default value of `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to delta.
+- BREAKING CHANGE: Change the default behavior of logging framework
+  instrumentations (for Bunyan, Pino, and Winston), to *not* do "log sending"
+  by default. "Log sending" is the feature name of
+  [`@opentelemetry/instrumentation-bunyan`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-bunyan/README.md#log-sending),
+  [`@opentelemetry/instrumentation-pino`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-pino/README.md#log-sending), and
+  [`@opentelemetry/instrumentation-winston`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-winston/README.md#log-sending)
+  to send log records directly to the configured OTLP collector. The new
+  default behavior effectively sets the default config for these
+  instrumentations to `{disableLogSending: true}`.
+
+  This default behavior differs from the current default in OpenTelemetry JS.
+  [OpenTelemetry **Java** instrumentation docs](https://opentelemetry.io/docs/languages/java/instrumentation/#log-instrumentation)
+  provide an argument for why log sending (or "Direct to collector") should be
+  opt-in. A common workflow for applications is to log to file or stdout and
+  have some external process collect those logs. In those cases, if the
+  OpenTelemetry SDK was *also* sending logs directly, then the telemetry
+  backend would very likely have duplicate logs.
+
+  This is controlled by the `ELASTIC_OTEL_ENABLE_LOG_SENDING` environment variable.
+  To enable log-sending by default, set `ELASTIC_OTEL_ENABLE_LOG_SENDING=true`.
+
+- BREAKING CHANGE: Set default value of `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to delta.
   This change is done to follow the recommendations specified in the [EDOT docs](https://github.com/elastic/opentelemetry/pull/63).
   (https://github.com/elastic/elastic-otel-node/pull/670)
 

--- a/packages/opentelemetry-node/test/instr-pino.test.js
+++ b/packages/opentelemetry-node/test/instr-pino.test.js
@@ -11,12 +11,40 @@ const {runTestFixtures} = require('./testutils');
 /** @type {import('./testutils').TestFixture[]} */
 const testFixtures = [
     {
-        name: 'use-pino',
+        name: 'use-pino (default config)',
         args: ['./fixtures/use-pino.js'],
         cwd: __dirname,
         env: {
             NODE_OPTIONS: '--require=@elastic/opentelemetry-node',
             OTEL_LOG_LEVEL: 'none',
+        },
+        versionRanges: {
+            // pino@9.3.0 breaks 14.17.0 compat.
+            node: '>=14.18.0',
+        },
+        // verbose: true,
+        checkResult: (t, err, stdout, _stderr) => {
+            t.error(err, `exited successfully: err=${err}`);
+            // Clumsy pass of stdout info to `checkTelemetry`.
+            t.recs = stdout.trim().split(/\n/g).map(JSON.parse);
+        },
+        checkTelemetry: (t, col) => {
+            const spans = col.sortedSpans;
+            t.equal(spans.length, 1);
+            t.equal(t.recs.length, 2);
+            // We expect telemetry to *not* have logs by default (see
+            // ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING).
+            t.equal(col.logs.length, 0);
+        },
+    },
+    {
+        name: 'use-pino (ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING=true)',
+        args: ['./fixtures/use-pino.js'],
+        cwd: __dirname,
+        env: {
+            NODE_OPTIONS: '--require=@elastic/opentelemetry-node',
+            OTEL_LOG_LEVEL: 'none',
+            ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING: 'true',
         },
         versionRanges: {
             // pino@9.3.0 breaks 14.17.0 compat.
@@ -42,10 +70,18 @@ const testFixtures = [
             t.equal(recs[1].trace_id, spans[0].traceId);
             t.equal(recs[1].span_id, spans[0].spanId);
 
-            // TODO: instr-pino doesn't yet support log-sending, so we don't
-            // yet expect logs sent via OTLP.
-            // const logs = col.logs;
-            // ...
+            const logs = col.logs;
+            t.equal(logs.length, 2);
+
+            t.equal(logs[0].severityText, 'info');
+            t.equal(logs[0].body, 'hi');
+            t.deepEqual(logs[0].attributes, {foo: 'bar'});
+            t.equal(logs[0].scope.name, '@opentelemetry/instrumentation-pino');
+
+            t.equal(logs[1].severityText, 'info');
+            t.equal(logs[1].body, 'with span info');
+            t.equal(logs[1].traceId, spans[0].traceId);
+            t.equal(logs[1].spanId, spans[0].spanId);
         },
     },
 ];


### PR DESCRIPTION
Closes: https://github.com/elastic/elastic-otel-node/issues/680
