### PR TITLE
fix(otel-node): use sdk to resolve metrics exporters

### DIFF
--- a/packages/opentelemetry-node/lib/sdk.js
+++ b/packages/opentelemetry-node/lib/sdk.js
@@ -11,6 +11,7 @@ const {
     getBooleanFromEnv,
     getNumberFromEnv,
     getStringFromEnv,
+    getStringListFromEnv,
 } = require('@opentelemetry/core');
 const {
     api,
@@ -144,37 +145,19 @@ function startNodeSDK(cfg = {}) {
     }
 
     // TODO: How does this differ from `OTEL_METRICS_EXPORTER=none` in sdk-node?
-    const metricsDisabled =
-        getBooleanFromEnv('ELASTIC_OTEL_METRICS_DISABLED') ?? false;
-    if (!metricsDisabled) {
-        const metricsExportProtocol =
-            getStringFromEnv('OTEL_EXPORTER_OTLP_METRICS_PROTOCOL') ||
-            getStringFromEnv('OTEL_EXPORTER_OTLP_PROTOCOL') ||
-            'http/protobuf';
-        let metricExporterType =
-            exporterPkgNameFromEnvVar[metricsExportProtocol];
-        if (!metricExporterType) {
-            log.warn(
-                `Metrics exporter protocol "${metricsExportProtocol}" unknown. Using default "http/protobuf" protocol`
-            );
-            metricExporterType = 'proto';
-        }
-        log.trace(`Metrics exporter protocol set to ${metricsExportProtocol}`);
-        const {OTLPMetricExporter} = require(
-            `@opentelemetry/exporter-metrics-otlp-${metricExporterType}`
-        );
+    // The implementation in SDK does treats the undefined and 'none' value
+    // as same. https://github.com/open-telemetry/opentelemetry-js/blob/dac72912b3a895c91ee95cfa39a22a916411ba4c/experimental/packages/opentelemetry-sdk-node/src/sdk.ts#L117
+    // According to https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection
+    // the default should be 'otlp' so IMHO the implementation is wrong
 
-        // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader
-        const metricsInterval =
-            getNumberFromEnv('OTEL_METRIC_EXPORT_INTERVAL') ?? 60000;
-        const metricsTimeout =
-            getNumberFromEnv('OTEL_METRIC_EXPORT_TIMEOUT') ?? 30000;
-
-        defaultConfig.metricReader = new metrics.PeriodicExportingMetricReader({
-            exporter: new OTLPMetricExporter(),
-            exportIntervalMillis: metricsInterval,
-            exportTimeoutMillis: metricsTimeout,
-        });
+    // We need to set the default value if env var is not defined until it's fixed in
+    // upstream SDK
+    if (!process.env.OTEL_METRICS_EXPORTER) {
+        process.env.OTEL_METRICS_EXPORTER = 'otlp';
+    }
+    const metricsExporters = getStringListFromEnv('OTEL_METRICS_EXPORTER');
+    const metricsEnabled = metricsExporters.every(e => e !== 'none');
+    if (metricsEnabled) {
         defaultConfig.views = [
             // Add views for `host-metrics` to avoid excess of data being sent
             // to the server.
@@ -211,7 +194,7 @@ function startNodeSDK(cfg = {}) {
     sdk.start(); // .start() *does* use `process.env` though I think it should not.
     restoreEnvironment();
 
-    if (!metricsDisabled) {
+    if (metricsEnabled) {
         // TODO: make this configurable, user might collect host metrics with a separate utility. Perhaps use 'host-metrics' in DISABLED_INSTRs existing env var.
         enableHostMetrics();
     }

--- a/packages/opentelemetry-node/lib/sdk.js
+++ b/packages/opentelemetry-node/lib/sdk.js
@@ -150,6 +150,7 @@ function startNodeSDK(cfg = {}) {
 
     // We need to set the default value if env var is not defined until it's fixed in
     // upstream SDK
+    // TODO: remove this when https://github.com/open-telemetry/opentelemetry-js/issues/5612 is closed
     if (!process.env.OTEL_METRICS_EXPORTER?.trim()) {
         process.env.OTEL_METRICS_EXPORTER = 'otlp';
     }

--- a/packages/opentelemetry-node/lib/sdk.js
+++ b/packages/opentelemetry-node/lib/sdk.js
@@ -9,7 +9,6 @@ const os = require('os');
 
 const {
     getBooleanFromEnv,
-    getNumberFromEnv,
     getStringFromEnv,
     getStringListFromEnv,
 } = require('@opentelemetry/core');
@@ -156,7 +155,7 @@ function startNodeSDK(cfg = {}) {
         process.env.OTEL_METRICS_EXPORTER = 'otlp';
     }
     const metricsExporters = getStringListFromEnv('OTEL_METRICS_EXPORTER');
-    const metricsEnabled = metricsExporters.every(e => e !== 'none');
+    const metricsEnabled = metricsExporters.every((e) => e !== 'none');
     if (metricsEnabled) {
         defaultConfig.views = [
             // Add views for `host-metrics` to avoid excess of data being sent

--- a/packages/opentelemetry-node/lib/sdk.js
+++ b/packages/opentelemetry-node/lib/sdk.js
@@ -143,7 +143,6 @@ function startNodeSDK(cfg = {}) {
         process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = 'delta';
     }
 
-    // TODO: How does this differ from `OTEL_METRICS_EXPORTER=none` in sdk-node?
     // The implementation in SDK does treats the undefined and 'none' value
     // as same. https://github.com/open-telemetry/opentelemetry-js/blob/dac72912b3a895c91ee95cfa39a22a916411ba4c/experimental/packages/opentelemetry-sdk-node/src/sdk.ts#L117
     // According to https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection

--- a/packages/opentelemetry-node/test/OTEL_EXPORTER_OTLP_PROTOCOL.test.js
+++ b/packages/opentelemetry-node/test/OTEL_EXPORTER_OTLP_PROTOCOL.test.js
@@ -97,7 +97,11 @@ const testFixtures = [
                 getLogs(lines).some((log) => log.msg.includes(text));
             t.ok(hasLog('Logs exporter protocol "bogus" unknown.'));
             // Log from upstream SDK
-            t.ok(hasLog('Unsupported OTLP metrics protocol: "bogus". Using http/protobuf.'));
+            t.ok(
+                hasLog(
+                    'Unsupported OTLP metrics protocol: "bogus". Using http/protobuf.'
+                )
+            );
         },
     },
     {
@@ -132,7 +136,11 @@ const testFixtures = [
             const hasLog = (text) =>
                 getLogs(lines).some((log) => log.msg.includes(text));
             // Log from upstream SDK
-            t.ok(hasLog('Unsupported OTLP metrics protocol: "bogus". Using http/protobuf.'));
+            t.ok(
+                hasLog(
+                    'Unsupported OTLP metrics protocol: "bogus". Using http/protobuf.'
+                )
+            );
         },
     },
 ];

--- a/packages/opentelemetry-node/test/OTEL_EXPORTER_OTLP_PROTOCOL.test.js
+++ b/packages/opentelemetry-node/test/OTEL_EXPORTER_OTLP_PROTOCOL.test.js
@@ -24,7 +24,6 @@ const testFixtures = [
                 getLogs(lines).some((log) => log.msg.includes(text));
             // Note: `testutils.js` sets the default protocol to 'http/json' via env var OTEL_EXPORTER_OTLP_PROTOCOL
             t.ok(hasLog('Logs exporter protocol set to http/json'));
-            t.ok(hasLog('Metrics exporter protocol set to http/json'));
         },
     },
     {
@@ -43,7 +42,6 @@ const testFixtures = [
             const hasLog = (text) =>
                 getLogs(lines).some((log) => log.msg.includes(text));
             t.ok(hasLog('Logs exporter protocol set to grpc'));
-            t.ok(hasLog('Metrics exporter protocol set to grpc'));
         },
     },
     {
@@ -62,8 +60,6 @@ const testFixtures = [
             const hasLog = (text) =>
                 getLogs(lines).some((log) => log.msg.includes(text));
             t.ok(hasLog('Logs exporter protocol set to grpc'));
-            // Note: `testutils.js` sets the default protocol to 'http/json' via env var OTEL_EXPORTER_OTLP_PROTOCOL
-            t.ok(hasLog('Metrics exporter protocol set to http/json'));
         },
     },
     {
@@ -83,7 +79,6 @@ const testFixtures = [
                 getLogs(lines).some((log) => log.msg.includes(text));
             // Note: `testutils.js` sets the default protocol to 'http/json' via env var OTEL_EXPORTER_OTLP_PROTOCOL
             t.ok(hasLog('Logs exporter protocol set to http/json'));
-            t.ok(hasLog('Metrics exporter protocol set to grpc'));
         },
     },
     {
@@ -101,7 +96,8 @@ const testFixtures = [
             const hasLog = (text) =>
                 getLogs(lines).some((log) => log.msg.includes(text));
             t.ok(hasLog('Logs exporter protocol "bogus" unknown.'));
-            t.ok(hasLog('Metrics exporter protocol "bogus" unknown.'));
+            // Log from upstream SDK
+            t.ok(hasLog('Unsupported OTLP metrics protocol: "bogus". Using http/protobuf.'));
         },
     },
     {
@@ -135,7 +131,8 @@ const testFixtures = [
             const lines = stdout.split('\n');
             const hasLog = (text) =>
                 getLogs(lines).some((log) => log.msg.includes(text));
-            t.ok(hasLog('Metrics exporter protocol "bogus" unknown.'));
+            // Log from upstream SDK
+            t.ok(hasLog('Unsupported OTLP metrics protocol: "bogus". Using http/protobuf.'));
         },
     },
 ];

--- a/packages/opentelemetry-node/test/OTEL_METRICS_EXPORTER.test.js
+++ b/packages/opentelemetry-node/test/OTEL_METRICS_EXPORTER.test.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const {test} = require('tape');
+const {runTestFixtures} = require('./testutils');
+
+/** @type {import('./testutils').TestFixture[]} */
+const testFixtures = [
+    {
+        // TODO
+        name: 'basic scenario with a single value (OTEL_METRICS_EXPORTER=console)',
+        args: ['./fixtures/use-http-server-metrics.js'],
+        cwd: __dirname,
+        env: {
+            NODE_OPTIONS: '--import=@elastic/opentelemetry-node',
+            OTEL_METRICS_EXPORTER: 'console',
+            // The default metrics interval is 30s, which makes for a slow test.
+            // However, too low a value runs into possible:
+            //      PeriodicExportingMetricReader: metrics collection errors TimeoutError: Operation timed out.
+            // which can lead to test data surprises.
+            OTEL_METRIC_EXPORT_INTERVAL: '1000',
+            OTEL_METRIC_EXPORT_TIMEOUT: '900',
+        },
+        // verbose: true,
+        checkResult: (t, err, stdout) => {
+            t.error(err);
+            const lines = stdout.split('\n');
+            const hasLog = (text) => lines.some((l) => l.includes(text));
+            // Logs from the console exporter are not JSON parseable
+            // so we check presence of some metric names
+            t.ok(hasLog(`name: 'http.client.request.duration'`));
+            t.ok(hasLog(`name: 'nodejs.eventloop.utilization'`));
+            t.ok(hasLog(`name: 'nodejs.eventloop.delay.min'`));
+            t.ok(hasLog(`name: 'nodejs.eventloop.delay.max'`));
+        },
+        checkTelemetry: (t, col) => {
+            t.ok(col.metrics.length === 0);
+        },
+    },
+    {
+        // TODO
+        name: 'basic scenario with a multiple values (OTEL_METRICS_EXPORTER=otlp,console)',
+        args: ['./fixtures/use-http-server-metrics.js'],
+        cwd: __dirname,
+        env: {
+            NODE_OPTIONS: '--import=@elastic/opentelemetry-node',
+            OTEL_METRICS_EXPORTER: 'otlp,console',
+            // The default metrics interval is 30s, which makes for a slow test.
+            // However, too low a value runs into possible:
+            //      PeriodicExportingMetricReader: metrics collection errors TimeoutError: Operation timed out.
+            // which can lead to test data surprises.
+            OTEL_METRIC_EXPORT_INTERVAL: '1000',
+            OTEL_METRIC_EXPORT_TIMEOUT: '900',
+        },
+        // verbose: true,
+        checkResult: (t, err, stdout) => {
+            t.error(err);
+            const lines = stdout.split('\n');
+            const hasLog = (text) => lines.some((l) => l.includes(text));
+            // Logs from the console exporter are not JSON parseable
+            // so we check presence of some metric names
+            t.ok(hasLog(`name: 'http.client.request.duration'`));
+            t.ok(hasLog(`name: 'nodejs.eventloop.utilization'`));
+            t.ok(hasLog(`name: 'nodejs.eventloop.delay.min'`));
+            t.ok(hasLog(`name: 'nodejs.eventloop.delay.max'`));
+        },
+        checkTelemetry: (t, col) => {
+            t.ok(col.metrics.length > 0);
+        },
+    },
+];
+
+// ----- main line -----
+
+test('OTEL_METRICS_EXPORTER', (suite) => {
+    runTestFixtures(suite, testFixtures);
+    suite.end();
+});

--- a/packages/opentelemetry-node/test/OTEL_METRICS_EXPORTER.test.js
+++ b/packages/opentelemetry-node/test/OTEL_METRICS_EXPORTER.test.js
@@ -9,38 +9,6 @@ const {runTestFixtures} = require('./testutils');
 /** @type {import('./testutils').TestFixture[]} */
 const testFixtures = [
     {
-        // TODO
-        name: 'basic scenario with a single value (OTEL_METRICS_EXPORTER=console)',
-        args: ['./fixtures/use-http-server-metrics.js'],
-        cwd: __dirname,
-        env: {
-            NODE_OPTIONS: '--import=@elastic/opentelemetry-node',
-            OTEL_METRICS_EXPORTER: 'console',
-            // The default metrics interval is 30s, which makes for a slow test.
-            // However, too low a value runs into possible:
-            //      PeriodicExportingMetricReader: metrics collection errors TimeoutError: Operation timed out.
-            // which can lead to test data surprises.
-            OTEL_METRIC_EXPORT_INTERVAL: '1000',
-            OTEL_METRIC_EXPORT_TIMEOUT: '900',
-        },
-        // verbose: true,
-        checkResult: (t, err, stdout) => {
-            t.error(err);
-            const lines = stdout.split('\n');
-            const hasLog = (text) => lines.some((l) => l.includes(text));
-            // Logs from the console exporter are not JSON parseable
-            // so we check presence of some metric names
-            t.ok(hasLog(`name: 'http.client.request.duration'`));
-            t.ok(hasLog(`name: 'nodejs.eventloop.utilization'`));
-            t.ok(hasLog(`name: 'nodejs.eventloop.delay.min'`));
-            t.ok(hasLog(`name: 'nodejs.eventloop.delay.max'`));
-        },
-        checkTelemetry: (t, col) => {
-            t.ok(col.metrics.length === 0);
-        },
-    },
-    {
-        // TODO
         name: 'basic scenario with a multiple values (OTEL_METRICS_EXPORTER=otlp,console)',
         args: ['./fixtures/use-http-server-metrics.js'],
         cwd: __dirname,


### PR DESCRIPTION
Fixes: #684 