### PR TITLE
feat: add CORS support for browser agents

### DIFF
--- a/packages/mockotlpserver/lib/http.js
+++ b/packages/mockotlpserver/lib/http.js
@@ -194,9 +194,8 @@ class HttpService extends Service {
                     // - something else
                     // PS: maybe collector could be able to tell the sdk/distro to stop sending
                     // because of: high load, sample rate changed, et al??
-                    // let resHeaders = isBrowserReq ? corsHeaders : {};
                     /** @type {http.OutgoingHttpHeaders} */
-                    let resHeaders = {};
+                    const resHeaders = isBrowserReq ? corsHeaders : {};
                     let resBody = null;
                     if (contentType === 'application/json') {
                         resBody = JSON.stringify({

--- a/packages/mockotlpserver/lib/http.js
+++ b/packages/mockotlpserver/lib/http.js
@@ -58,9 +58,9 @@ function isBrowserUserAgent(ua) {
 
 /**
  * @param {http.IncomingMessage} req
- * @param {http.ServerResponse} res 
+ * @param {http.ServerResponse} res
  * @param {string} [errMsg]
- * @param {number} [errCode] 
+ * @param {number} [errCode]
  */
 function badRequest(
     req,

--- a/packages/mockotlpserver/lib/http.js
+++ b/packages/mockotlpserver/lib/http.js
@@ -43,16 +43,13 @@ function diagChFromReqUrl(reqUrl) {
 
 // helper functions
 /**
- * @param {string} ua 
+ * @param {string} ua
  * @returns {boolean}
  */
 function isBrowserUserAgent(ua) {
-    return [
-        'Mozilla/',
-        'AppleWebKit/',
-        'Chrome/',
-        'Safari/',
-    ].some((str) => ua.includes(str));
+    return ['Mozilla/', 'AppleWebKit/', 'Chrome/', 'Safari/'].some((str) =>
+        ua.includes(str)
+    );
 }
 
 function badRequest(


### PR DESCRIPTION
OTEL agents which run in a web application may send data to a collector which is not in the same domain. In this scenario browsers do check CORS in order to do the actual request. The server now handle `OPTIONS` requests and sends back the required headers for CORS.