### PR TITLE
chore: use CODEOWNERS instead of 'reviewers' in dependabot.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*  @elastic/apm-agent-node-js
+/.github/workflows/  @elastic/apm-agent-node-js @elastic/observablt-ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "elastic/apm-agent-node-js"
     groups:
       opentelemetry:
         patterns:
@@ -32,8 +30,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "elastic/apm-agent-node-js"
     groups:
       mockotlpserver:
         patterns:
@@ -44,8 +40,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "elastic/apm-agent-node-js"
     ignore:
       # Locked to the same version being used by opentelemetry-js-contrib.
       - dependency-name: "@types/node"
@@ -63,8 +57,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "elastic/apm-agent-node-js"
     ignore:
       # eslint-related deps are skipped until we have upgraded to eslint@9
       # https://github.com/elastic/elastic-otel-node/pull/155
@@ -91,14 +83,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "elastic/apm-agent-node-js"
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    reviewers:
-      - "elastic/observablt-ci"
-      - "elastic/apm-agent-node-js"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -111,7 +98,5 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     registries: "*"
-    reviewers:
-      - "elastic/apm-agent-node-js"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

> ... we’re removing the [Dependabot reviewers configuration option](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#reviewers--) on Tuesday, May 20, 2025.