### PR TITLE
chore: restore ELASTIC_OTEL_DISABLE_METRICS behaviour

### DIFF
--- a/packages/opentelemetry-node/lib/sdk.js
+++ b/packages/opentelemetry-node/lib/sdk.js
@@ -110,9 +110,11 @@ function startNodeSDK(cfg = {}) {
         if (getBooleanFromEnv('ELASTIC_OTEL_METRICS_DISABLED')) {
             process.env.OTEL_METRICS_EXPORTER = 'none';
             if (process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS) {
-                process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS += ',runtime-node';
+                process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS +=
+                    ',runtime-node';
             } else {
-                process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS = 'runtime-node';
+                process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS =
+                    'runtime-node';
             }
         }
     }


### PR DESCRIPTION
The deprecation of `ELASTIC_OTEL_METRICS_DISABLED` [PR](https://github.com/elastic/elastic-otel-node/pull/768) changed a bit the behaviour of EDOT.  Although no metric is exported when setting it to `true` the nodejs runtime instrumentation is activated and previously it wasn't

After a discussion there is an agreement on restoring the same behaviour. Ref: https://github.com/elastic/opentelemetry/pull/230/files#r2093462817

It has been tested locally that the env var `OTEL_NODE_DISABLED_INSTRUMENTATIONS` is updated properly before resolving the instrumentation list.