### PR TITLE
chore: update dependabot config for *docker* to point to the dirs that have Dockerfile files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,7 +96,27 @@ updates:
           - "*"
 
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/examples/otel-operator/Dockerfile"
+    registries: "*"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/packages/mockopampserver/Dockerfile"
+    registries: "*"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/packages/mockotlpserver/Dockerfile"
+    registries: "*"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/packages/mockotlpserver/share/k8s/example-app-manual/Dockerfile"
+    registries: "*"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/packages/opentelemetry-node/Dockerfile"
     registries: "*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Refs: https://github.com/elastic/elastic-otel-node/pull/679
