### PR TITLE
chore: drop @types/node devDep at top-level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^22.15.30",
         "dependency-check": "^4.1.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "lint:fix": "eslint --ext=js,mjs,cjs .eslintrc.js scripts examples --fix && ls -d packages/* | while read d; do (cd $d; npm run lint:fix); done"
   },
   "devDependencies": {
-    "@types/node": "^22.15.30",
     "dependency-check": "^4.1.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
I think this may be a vestigial dep.
