### PR TITLE
release opamp-client-node 0.2.0; publish types

### DIFF
--- a/packages/opamp-client-node/CHANGELOG.md
+++ b/packages/opamp-client-node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @elastic/opamp-client-node Changelog
 
+## v0.2.0
+
+- Publish types.
+
 ## v0.1.0
 
 Initial release.

--- a/packages/opamp-client-node/package-lock.json
+++ b/packages/opamp-client-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opamp-client-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opamp-client-node",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",

--- a/packages/opamp-client-node/package.json
+++ b/packages/opamp-client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opamp-client-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "commonjs",
   "description": "an OpAMP client for Node.js",
   "publishConfig": {
@@ -28,19 +28,22 @@
     "example": "cd examples && node use-opamp-client.js | pino-pretty",
     "example:instrumented": "cd examples && node --import ../../opentelemetry-node/import.mjs use-opamp-client.js | pino-pretty",
     "gen:protos": "buf generate",
+    "gen:types": "rm -rf types && tsc",
     "lint": "npm run lint:eslint && npm run lint:deps && npm run lint:license-files && npm run lint:types",
     "lint:eslint": "eslint --ext=js,mjs,cjs .",
     "lint:deps": "dependency-check '{examples,lib,test}/**/*.js' -i @bufbuild/buf -i @bufbuild/protoc-gen-es -i pino-pretty",
     "lint:fix": "eslint --ext=js,mjs,cjs --fix .",
     "lint:license-files": "../../scripts/gen-notice.sh --lint .",
-    "lint:types": "rm -rf build/lint-types && tsc --outDir build/lint-types",
+    "lint:types": "rm -rf build/lint-types && tsc --outDir build/lint-types && diff -ur types build/lint-types",
     "test": "tape test/**/*.test.js"
   },
   "files": [
     "CHANGELOG.md",
-    "lib"
+    "lib",
+    "types"
   ],
   "main": "lib/index.js",
+  "types": "types/index.d.ts",
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
     "undici": "^6.21.2",

--- a/packages/opamp-client-node/types/generated/anyvalue_pb.d.ts
+++ b/packages/opamp-client-node/types/generated/anyvalue_pb.d.ts
@@ -1,0 +1,25 @@
+export const __esModule: boolean;
+/**
+ * Describes the file anyvalue.proto.
+ */
+export const file_anyvalue: import("@bufbuild/protobuf").DescFile;
+/**
+ * Describes the message opamp.proto.AnyValue.
+ * Use `create(AnyValueSchema)` to create a new message.
+ */
+export const AnyValueSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.ArrayValue.
+ * Use `create(ArrayValueSchema)` to create a new message.
+ */
+export const ArrayValueSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.KeyValueList.
+ * Use `create(KeyValueListSchema)` to create a new message.
+ */
+export const KeyValueListSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.KeyValue.
+ * Use `create(KeyValueSchema)` to create a new message.
+ */
+export const KeyValueSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;

--- a/packages/opamp-client-node/types/generated/opamp_pb.d.ts
+++ b/packages/opamp-client-node/types/generated/opamp_pb.d.ts
@@ -1,0 +1,282 @@
+export const __esModule: boolean;
+/**
+ * Describes the file opamp.proto.
+ */
+export const file_opamp: import("@bufbuild/protobuf").DescFile;
+/**
+ * Describes the message opamp.proto.AgentToServer.
+ * Use `create(AgentToServerSchema)` to create a new message.
+ */
+export const AgentToServerSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.AgentDisconnect.
+ * Use `create(AgentDisconnectSchema)` to create a new message.
+ */
+export const AgentDisconnectSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.ConnectionSettingsRequest.
+ * Use `create(ConnectionSettingsRequestSchema)` to create a new message.
+ */
+export const ConnectionSettingsRequestSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.OpAMPConnectionSettingsRequest.
+ * Use `create(OpAMPConnectionSettingsRequestSchema)` to create a new message.
+ */
+export const OpAMPConnectionSettingsRequestSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.CertificateRequest.
+ * Use `create(CertificateRequestSchema)` to create a new message.
+ */
+export const CertificateRequestSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.AvailableComponents.
+ * Use `create(AvailableComponentsSchema)` to create a new message.
+ */
+export const AvailableComponentsSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.ComponentDetails.
+ * Use `create(ComponentDetailsSchema)` to create a new message.
+ */
+export const ComponentDetailsSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.ServerToAgent.
+ * Use `create(ServerToAgentSchema)` to create a new message.
+ */
+export const ServerToAgentSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.OpAMPConnectionSettings.
+ * Use `create(OpAMPConnectionSettingsSchema)` to create a new message.
+ */
+export const OpAMPConnectionSettingsSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.TelemetryConnectionSettings.
+ * Use `create(TelemetryConnectionSettingsSchema)` to create a new message.
+ */
+export const TelemetryConnectionSettingsSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.OtherConnectionSettings.
+ * Use `create(OtherConnectionSettingsSchema)` to create a new message.
+ */
+export const OtherConnectionSettingsSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.Headers.
+ * Use `create(HeadersSchema)` to create a new message.
+ */
+export const HeadersSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.Header.
+ * Use `create(HeaderSchema)` to create a new message.
+ */
+export const HeaderSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.TLSCertificate.
+ * Use `create(TLSCertificateSchema)` to create a new message.
+ */
+export const TLSCertificateSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.ConnectionSettingsOffers.
+ * Use `create(ConnectionSettingsOffersSchema)` to create a new message.
+ */
+export const ConnectionSettingsOffersSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.PackagesAvailable.
+ * Use `create(PackagesAvailableSchema)` to create a new message.
+ */
+export const PackagesAvailableSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.PackageAvailable.
+ * Use `create(PackageAvailableSchema)` to create a new message.
+ */
+export const PackageAvailableSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.DownloadableFile.
+ * Use `create(DownloadableFileSchema)` to create a new message.
+ */
+export const DownloadableFileSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.ServerErrorResponse.
+ * Use `create(ServerErrorResponseSchema)` to create a new message.
+ */
+export const ServerErrorResponseSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.RetryInfo.
+ * Use `create(RetryInfoSchema)` to create a new message.
+ */
+export const RetryInfoSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.ServerToAgentCommand.
+ * Use `create(ServerToAgentCommandSchema)` to create a new message.
+ */
+export const ServerToAgentCommandSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.AgentDescription.
+ * Use `create(AgentDescriptionSchema)` to create a new message.
+ */
+export const AgentDescriptionSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.ComponentHealth.
+ * Use `create(ComponentHealthSchema)` to create a new message.
+ */
+export const ComponentHealthSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.EffectiveConfig.
+ * Use `create(EffectiveConfigSchema)` to create a new message.
+ */
+export const EffectiveConfigSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.RemoteConfigStatus.
+ * Use `create(RemoteConfigStatusSchema)` to create a new message.
+ */
+export const RemoteConfigStatusSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.PackageStatuses.
+ * Use `create(PackageStatusesSchema)` to create a new message.
+ */
+export const PackageStatusesSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.PackageStatus.
+ * Use `create(PackageStatusSchema)` to create a new message.
+ */
+export const PackageStatusSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.PackageDownloadDetails.
+ * Use `create(PackageDownloadDetailsSchema)` to create a new message.
+ */
+export const PackageDownloadDetailsSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.AgentIdentification.
+ * Use `create(AgentIdentificationSchema)` to create a new message.
+ */
+export const AgentIdentificationSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.AgentRemoteConfig.
+ * Use `create(AgentRemoteConfigSchema)` to create a new message.
+ */
+export const AgentRemoteConfigSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.AgentConfigMap.
+ * Use `create(AgentConfigMapSchema)` to create a new message.
+ */
+export const AgentConfigMapSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.AgentConfigFile.
+ * Use `create(AgentConfigFileSchema)` to create a new message.
+ */
+export const AgentConfigFileSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.CustomCapabilities.
+ * Use `create(CustomCapabilitiesSchema)` to create a new message.
+ */
+export const CustomCapabilitiesSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the message opamp.proto.CustomMessage.
+ * Use `create(CustomMessageSchema)` to create a new message.
+ */
+export const CustomMessageSchema: import("@bufbuild/protobuf/codegenv1").GenMessage<import("@bufbuild/protobuf").Message, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Describes the enum opamp.proto.AgentToServerFlags.
+ */
+export const AgentToServerFlagsSchema: import("@bufbuild/protobuf/codegenv1").GenEnum<number, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * @generated from enum opamp.proto.AgentToServerFlags
+ */
+export const AgentToServerFlags: {
+    [key: number]: string;
+    [k: string]: string | number;
+};
+/**
+ * Describes the enum opamp.proto.ServerToAgentFlags.
+ */
+export const ServerToAgentFlagsSchema: import("@bufbuild/protobuf/codegenv1").GenEnum<number, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * @generated from enum opamp.proto.ServerToAgentFlags
+ */
+export const ServerToAgentFlags: {
+    [key: number]: string;
+    [k: string]: string | number;
+};
+/**
+ * Describes the enum opamp.proto.ServerCapabilities.
+ */
+export const ServerCapabilitiesSchema: import("@bufbuild/protobuf/codegenv1").GenEnum<number, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * @generated from enum opamp.proto.ServerCapabilities
+ */
+export const ServerCapabilities: {
+    [key: number]: string;
+    [k: string]: string | number;
+};
+/**
+ * Describes the enum opamp.proto.PackageType.
+ */
+export const PackageTypeSchema: import("@bufbuild/protobuf/codegenv1").GenEnum<number, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * The type of the package, either an addon or a top-level package.
+ * Status: [Beta]
+ *
+ * @generated from enum opamp.proto.PackageType
+ */
+export const PackageType: {
+    [key: number]: string;
+    [k: string]: string | number;
+};
+/**
+ * Describes the enum opamp.proto.ServerErrorResponseType.
+ */
+export const ServerErrorResponseTypeSchema: import("@bufbuild/protobuf/codegenv1").GenEnum<number, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * @generated from enum opamp.proto.ServerErrorResponseType
+ */
+export const ServerErrorResponseType: {
+    [key: number]: string;
+    [k: string]: string | number;
+};
+/**
+ * Describes the enum opamp.proto.CommandType.
+ */
+export const CommandTypeSchema: import("@bufbuild/protobuf/codegenv1").GenEnum<number, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * Status: [Beta]
+ *
+ * @generated from enum opamp.proto.CommandType
+ */
+export const CommandType: {
+    [key: number]: string;
+    [k: string]: string | number;
+};
+/**
+ * Describes the enum opamp.proto.AgentCapabilities.
+ */
+export const AgentCapabilitiesSchema: import("@bufbuild/protobuf/codegenv1").GenEnum<number, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * @generated from enum opamp.proto.AgentCapabilities
+ */
+export const AgentCapabilities: {
+    [key: number]: string;
+    [k: string]: string | number;
+};
+/**
+ * Describes the enum opamp.proto.RemoteConfigStatuses.
+ */
+export const RemoteConfigStatusesSchema: import("@bufbuild/protobuf/codegenv1").GenEnum<number, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * @generated from enum opamp.proto.RemoteConfigStatuses
+ */
+export const RemoteConfigStatuses: {
+    [key: number]: string;
+    [k: string]: string | number;
+};
+/**
+ * Describes the enum opamp.proto.PackageStatusEnum.
+ */
+export const PackageStatusEnumSchema: import("@bufbuild/protobuf/codegenv1").GenEnum<number, import("@bufbuild/protobuf").JsonValue>;
+/**
+ * The status of this package.
+ * Status: [Beta]
+ *
+ * @generated from enum opamp.proto.PackageStatusEnum
+ */
+export const PackageStatusEnum: {
+    [key: number]: string;
+    [k: string]: string | number;
+};

--- a/packages/opamp-client-node/types/index.d.ts
+++ b/packages/opamp-client-node/types/index.d.ts
@@ -1,0 +1,8 @@
+import { DIAG_CH_SEND_SUCCESS } from "./opamp-client";
+import { DIAG_CH_SEND_FAIL } from "./opamp-client";
+import { DIAG_CH_SEND_SCHEDULE } from "./opamp-client";
+import { USER_AGENT } from "./opamp-client";
+import { createOpAMPClient } from "./opamp-client";
+import { AgentCapabilities } from "./generated/opamp_pb";
+import { RemoteConfigStatuses } from "./generated/opamp_pb";
+export { DIAG_CH_SEND_SUCCESS, DIAG_CH_SEND_FAIL, DIAG_CH_SEND_SCHEDULE, USER_AGENT, createOpAMPClient, AgentCapabilities, RemoteConfigStatuses };

--- a/packages/opamp-client-node/types/logging.d.ts
+++ b/packages/opamp-client-node/types/logging.d.ts
@@ -1,0 +1,10 @@
+export function logserA2S(a2s: any): any;
+export function logserS2A(s2a: any): any;
+export class NoopLogger {
+    trace(): void;
+    debug(): void;
+    info(): void;
+    error(): void;
+    warn(): void;
+    fatal(): void;
+}

--- a/packages/opamp-client-node/types/opamp-client.d.ts
+++ b/packages/opamp-client-node/types/opamp-client.d.ts
@@ -1,0 +1,297 @@
+/// <reference types="node" />
+/// <reference types="node" />
+export type AgentDescription = import('./generated/opamp_pb.js').AgentDescription;
+export type AgentToServer = import('./generated/opamp_pb.js').AgentToServer;
+export type RemoteConfigStatus = import('./generated/opamp_pb.js').RemoteConfigStatus;
+export type ServerToAgent = import('./generated/opamp_pb.js').ServerToAgent;
+export type AgentRemoteConfig = import('./generated/opamp_pb.js').AgentRemoteConfig;
+export type KeyValue = import('./generated/anyvalue_pb.js').KeyValue;
+export type AnyValue = import('./generated/anyvalue_pb.js').AnyValue;
+export type ArrayValue = import('./generated/anyvalue_pb.js').ArrayValue;
+export type OnMessageCallback = (data: OnMessageData) => any;
+export type OnMessageData = {
+    remoteConfig?: AgentRemoteConfig;
+};
+export type TLSConnectionOptions = import('tls').ConnectionOptions;
+export type ConnectOptions = Pick<TLSConnectionOptions, 'ca'>;
+export type OpAMPClientOptions = {
+    /**
+     * - A logger instance with .trace(), .debug(), etc.
+     * methods a la Pino/Bunyan/Luggite.
+     */
+    log?: any;
+    /**
+     * - The URL of the OpAMP server, including the
+     * path (typically '/v1/opamp').
+     */
+    endpoint: string;
+    /**
+     * - Additional HTTP headers to include in requests.
+     */
+    headers?: any;
+    /**
+     * - Globally unique identifier
+     * for the OpAMP agent. Should be a UUID v7. Could also be set to an OTel
+     * 'service.instance.id' resource attribute. If not provided, a UUID v7
+     * will generated.
+     */
+    instanceUid?: Uint8Array | string;
+    /**
+     * - Bitmask of capabilities to enable.
+     * Currently only the following are supported:
+     * - ReportsStatus (always on)
+     * - ReportsHeartbeat (always on, because using HTTP transport)
+     * - AcceptsRemoteConfig
+     * - ReportsRemoteConfig
+     * It is an error to specify other capabilities.
+     * https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agenttoservercapabilities
+     */
+    capabilities?: BigInt;
+    /**
+     * A callback of the form
+     * `({remoteConfig}) => {}` that is called when a server response provides
+     * data for the client. Currently the only type of data supported is
+     * remote config. Receiving remote config requires setting the
+     * `AcceptsRemoteConfig` capability in `capabilities`.
+     */
+    onMessage?: OnMessageCallback;
+    /**
+     * The approximate time between
+     * heartbeat messages sent by the client. Default 30.
+     */
+    heartbeatIntervalSeconds?: number;
+    /**
+     * The timeout (in milliseconds) to wait
+     * for the response headers on a request to the OpAMP server. Default 10s.
+     */
+    headersTimeout?: number;
+    /**
+     * The timeout (in milliseconds) to wait for
+     * the response body on a request to the OpAMP server. Default 10s.
+     */
+    bodyTimeout?: number;
+    /**
+     * A small subset of Undici client connect
+     * options (https://undici.nodejs.org/#/docs/api/Client?id=parameter-connectoptions):
+     * - 'ca'
+     */
+    connect?: ConnectOptions;
+    /**
+     * Diagnostics enabled, typically used for
+     * testing. When enabled, events will be published to the following
+     * diagnostics channels:
+     * - `opamp-client.send.success`: {a2s, s2a}
+     * - `opamp-client.send.fail`: {a2s, err, retryAfterMs}
+     * - `opamp-client.send.schedule`: {delayMs, errCount}
+     *
+     * TODO: enableCompression or similar option
+     * TODO: add {ConnectionOptions} [connect] with a subset of https://undici.nodejs.org/#/docs/api/Client?id=parameter-connectoptions e.g. as used in play.mjs for `ca: [cacert]` to conn to opamp-go example server. Or could expose the full ConnectOptions, but that's heavy.
+     */
+    diagEnabled?: boolean;
+};
+export const DIAG_CH_SEND_SUCCESS: "opamp-client.send.success";
+export const DIAG_CH_SEND_FAIL: "opamp-client.send.fail";
+export const DIAG_CH_SEND_SCHEDULE: "opamp-client.send.schedule";
+export const USER_AGENT: string;
+/**
+ * @param {OpAMPClientOptions} opts
+ */
+export function createOpAMPClient(opts: OpAMPClientOptions): OpAMPClient;
+/**
+ * @callback OnMessageCallback
+ * @param {OnMessageData} data
+ */
+/**
+ * @typedef {Object} OnMessageData
+ * @property {AgentRemoteConfig} [remoteConfig]
+ */
+/**
+ * @typedef {import('tls').ConnectionOptions} TLSConnectionOptions
+ */
+/**
+ * @typedef {Pick<TLSConnectionOptions, 'ca'>} ConnectOptions
+ */
+/**
+ * @typedef {Object} OpAMPClientOptions
+ * @property {Object} [log] - A logger instance with .trace(), .debug(), etc.
+ *      methods a la Pino/Bunyan/Luggite.
+ * @property {String} endpoint - The URL of the OpAMP server, including the
+ *      path (typically '/v1/opamp').
+ * @property {Object} [headers] - Additional HTTP headers to include in requests.
+ * @property {Uint8Array | string} [instanceUid] - Globally unique identifier
+ *      for the OpAMP agent. Should be a UUID v7. Could also be set to an OTel
+ *      'service.instance.id' resource attribute. If not provided, a UUID v7
+ *      will generated.
+ * @property {BigInt} [capabilities] - Bitmask of capabilities to enable.
+ *      Currently only the following are supported:
+ *          - ReportsStatus (always on)
+ *          - ReportsHeartbeat (always on, because using HTTP transport)
+ *          - AcceptsRemoteConfig
+ *          - ReportsRemoteConfig
+ *      It is an error to specify other capabilities.
+ *      https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agenttoservercapabilities
+ * @property {OnMessageCallback} [onMessage] A callback of the form
+ *      `({remoteConfig}) => {}` that is called when a server response provides
+ *      data for the client. Currently the only type of data supported is
+ *      remote config. Receiving remote config requires setting the
+ *      `AcceptsRemoteConfig` capability in `capabilities`.
+ * @property {Number} [heartbeatIntervalSeconds] The approximate time between
+ *      heartbeat messages sent by the client. Default 30.
+ * @property {number} [headersTimeout] The timeout (in milliseconds) to wait
+ *      for the response headers on a request to the OpAMP server. Default 10s.
+ * @property {number} [bodyTimeout] The timeout (in milliseconds) to wait for
+ *      the response body on a request to the OpAMP server. Default 10s.
+ * @property {ConnectOptions} [connect] A small subset of Undici client connect
+ *      options (https://undici.nodejs.org/#/docs/api/Client?id=parameter-connectoptions):
+ *          - 'ca'
+ * @property {boolean} [diagEnabled] Diagnostics enabled, typically used for
+ *      testing. When enabled, events will be published to the following
+ *      diagnostics channels:
+ *      - `opamp-client.send.success`: {a2s, s2a}
+ *      - `opamp-client.send.fail`: {a2s, err, retryAfterMs}
+ *      - `opamp-client.send.schedule`: {delayMs, errCount}
+ *
+ * TODO: enableCompression or similar option
+ * TODO: add {ConnectionOptions} [connect] with a subset of https://undici.nodejs.org/#/docs/api/Client?id=parameter-connectoptions e.g. as used in play.mjs for `ca: [cacert]` to conn to opamp-go example server. Or could expose the full ConnectOptions, but that's heavy.
+ */
+declare class OpAMPClient {
+    /**
+     * @param {OpAMPClientOptions} opts
+     */
+    constructor(opts: OpAMPClientOptions);
+    _log: any;
+    _endpoint: import("url").URL;
+    _headers: any;
+    _sequenceNum: bigint;
+    _instanceUid: Uint8Array;
+    _instanceUidStr: string;
+    _capabilities: bigint;
+    _heartbeatIntervalMs: number;
+    _onMessage: OnMessageCallback;
+    _diagChs: {
+        "opamp-client.send.success": import("diagnostics_channel").Channel<unknown, unknown>;
+        "opamp-client.send.fail": import("diagnostics_channel").Channel<unknown, unknown>;
+        "opamp-client.send.schedule": import("diagnostics_channel").Channel<unknown, unknown>;
+    };
+    _diagEnabled: boolean;
+    _started: boolean;
+    _shutdown: boolean;
+    _serverCapabilities: any;
+    /** @type {AgentDescription} */
+    _agentDescription: AgentDescription;
+    _remoteConfigStatus: import("./generated/opamp_pb").RemoteConfigStatus;
+    _numSendFailures: number;
+    _nextSendTime: number;
+    _nextSendTimeout: NodeJS.Timeout;
+    _queue: any[];
+    _httpClient: undici.Client;
+    /**
+     * setAgentDescription MUST be called before `.start()`.
+     * Can be called again later after start.
+     * See https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescription-message
+     *
+     * Dev Note: `desc` is *not* the raw `AgentDescription` type from bufbuild.
+     * This is for convenience in providing attributes as JS object, rather than
+     * the verbose proto-library-specific representation.
+     *
+     * @param {{identifyingAttributes?: object, nonIdentifyingAttributes?: object}} desc
+     */
+    setAgentDescription(desc: {
+        identifyingAttributes?: object;
+        nonIdentifyingAttributes?: object;
+    }): void;
+    _agentDescriptionSer: Uint8Array;
+    /**
+     * Dev Note: This client manages the `instanceUid`, so I'm not sure if this
+     * API method is useful. The instanceUid *can* be changed by the OpAMP
+     * server.
+     */
+    getInstanceUid(): Uint8Array;
+    start(): void;
+    /**
+     * Do an orderly shutdown.
+     * A shutdown OpAMPClient cannot be restarted.
+     */
+    shutdown(): Promise<void>;
+    /**
+     * setRemoteConfigStatus sets the current RemoteConfigStatus and, if
+     * changed, schedules sending a message to the server.
+     *
+     * May be called anytime after start(), including from the `onMessage`
+     * handler.
+     *
+     * @param {RemoteConfigStatus} remoteConfigStatus - The
+     *      `lastRemoteConfigHash` property must be set, other properties are
+     *      optional.
+     */
+    setRemoteConfigStatus(remoteConfigStatus: RemoteConfigStatus): void;
+    _hasCapReportsRemoteConfig(): bigint;
+    _hasCapAcceptsRemoteConfig(): bigint;
+    /**
+     * # How scheduling sending of messages from the OpAMP client works
+     *
+     * - Sending is done in `_sendMsg()` -- including retry/backoff handling.
+     *   We only ever want one active at a time.
+     * - New info to send can come from any of:
+     *      - A ServerToAgent.flags request to "ReportFullState". This is
+     *        handled as part of `_sendMsg` calling `_processServerToAgent()`.
+     *      - Client API methods being called, e.g. `.setRemoteConfigStatus()`.
+     *        These will append to the `_queue` and call `_scheduleSendSoon()`.
+     * - If there is info to send (e.g. new AgentDescription) it is on
+     *   `this._queue`.
+     * - When `_sendMsg()` finishes successfully, it checks the queue. If there
+     *   is something to send, it will `_scheduleSendSoon()` to flush the queue.
+     *   Otherwise it will `_scheduleSendHeartbeat()` to maintain periodic
+     *   heartbeats.
+     * - If `_sendMsg()` fails, there are a number of failure modes (see the
+     *   specifics in `_sendMsg`). Generally it will log some failure details,
+     *   re-enqueue the msg data to be sent and either retry sending after some
+     *   exponential backoff, or after a given Retry-After header time.
+     */
+    _scheduleSendSoon(): void;
+    _scheduleSendHeartbeat(): void;
+    /**
+     * @param {number} retryAfterMs
+     */
+    _scheduleSendRetryAfter(retryAfterMs: number): void;
+    _scheduleSendAfterErr(): void;
+    /**
+     * This should only be called by the other `_scheduleSend*` methods above.
+     *
+     * @param {number} delayMs
+     * @param {boolean} overrideExisting - Whether to override an existing
+     *      scheduled send, even if the existing one is *sooner* that the given
+     *      delayMs.
+     */
+    _scheduleSend(delayMs: number, overrideExisting: boolean): void;
+    /**
+     * Send a status update to the server, then schedule the next send.
+     * Data to send is either on `this._queue`, or this is a simple heartbeat.
+     *
+     * Dev Note: This sets `this._sending = true` for its duration. This
+     * function cannot throw, otherwise the client will be wedged.
+     *
+     * Error handling behaviour is loosely derived from the OpAMP spec,
+     * including sections "Establishing Connection", "Retrying Messages" and
+     * "Throttling". It isn't always clear the exact intent:
+     *
+     * - if `client.request()` rejects (no conn, headersTimeout): log.error, re-enqueue, schedule with backoff(30s .. 5min)
+     * - if HTTP 429 with valid `Retry-After` header: log.debug, re-enqueue, schedule for given time (min 30s)
+     * - if HTTP 503 with valid `Retry-After` header: log.error, re-enqueue, schedule for given time (min 30s)
+     * - if HTTP != 200 || content-type != protobuf: log.error, re-enqueue, schedule with backoff(30s .. 5min)
+     * - if `await res.body.bytes()` rejection (bodyTimeout): log.error, re-enqueue, schedule with backoff(30s .. 5min)
+     * - if s2a.errorResponse:
+     *     - if .type == "Unavailable" && .Details.retryAfterNanoseconds > 0: log.debug, re-enqueue, schedule for given time (min 30s)
+     *     - if .type == "BadRequest": log.error, do *not* re-enqueue, schedule for given time (min 30s)
+     *     - else: log.error, re-enqueue, schedule with backoff(30s .. 5min)
+     * - else success: process the `s2a` message
+     */
+    _sendMsg(): Promise<void>;
+    _sending: boolean;
+    /**
+     * @param {ServerToAgent} s2a
+     */
+    _processServerToAgent(s2a: ServerToAgent): void;
+}
+import undici = require("undici");
+export {};

--- a/packages/opamp-client-node/types/utils.d.ts
+++ b/packages/opamp-client-node/types/utils.d.ts
@@ -1,0 +1,41 @@
+export type KeyValue = import('./generated/anyvalue_pb.js').KeyValue;
+export type AnyValue = import('./generated/anyvalue_pb.js').AnyValue;
+/**
+ * @typedef {import('./generated/anyvalue_pb.js').KeyValue} KeyValue
+ * @typedef {import('./generated/anyvalue_pb.js').AnyValue} AnyValue
+ */
+export function jitter(val: any): any;
+export function isEqualUint8Array(a: any, b: any): boolean;
+/**
+ * Convert a JS object to the `KeyValue[]` type.
+ *
+ * @returns {KeyValue[]}
+ */
+export function keyValuesFromObj(obj: any): KeyValue[];
+/**
+ * Convert a `KeyValue[]` type to a JS object.
+ * For example, AgentDescription.identifying_attributes are of type `KeyValue[]`.
+ * Using that type directly is a huge PITA.
+ *
+ * @param {KeyValue[]} keyValues
+ * @returns {object}
+ */
+export function objFromKeyValues(keyValues: KeyValue[]): object;
+/**
+ * Parse a Retry-After HTTP header to a number of milliseconds.
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After
+ *
+ * This clamps to [30s, 1d], and defaults to 5 minutes if the value is not
+ * given or is invalid. The 30s value is from
+ * https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#plain-http-transport-2
+ * which says "The minimum recommended retry interval is 30 seconds."
+ *
+ * @param {string | undefined} header
+ * @returns {number}
+ */
+export function msFromRetryAfterHeader(header: string | undefined): number;
+/**
+ * Handle a retry-after value from a
+ * ServerErrorResponse.Details.value.retryAfterNanoseconds.
+ */
+export function msFromRetryAfterNs(ns: any): number;


### PR DESCRIPTION
Get `@elastic/opamp-client-node` to publish types, and make a v0.2.0 release.