### PR TITLE
release @elastic/opentelemetry-node@1.1.0

### DIFF
--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/opentelemetry-node Changelog
 
-## Unreleased
+## v1.1.0
 
 - **BREAKING CHANGE**: This includes an update to `@opentelemetry/instrumentation-aws-sdk`
   v0.54.0 which inclues the following breaking changes:

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-node",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/opentelemetry-instrumentation-openai": "^0.5.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "commonjs",
   "description": "Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js)",
   "publishConfig": {


### PR DESCRIPTION
# Highlights

- Restore support for bootstrapping via a custom file (e.g. `node --import ./telemetry.mjs ...`) rather than the typical `node --import @elastic/opentelemetry-node`.  This allows one to customize the SDK -- though we need to document this beyond the example at https://github.com/elastic/elastic-otel-node/blob/main/examples/telemetry.mjs.  Here is a TypeScript example: https://github.com/elastic/elastic-otel-node/blob/main/packages/opentelemetry-node/test/fixtures/an-esm-pkg/telemetry-typescript.ts
- Upstream `@opentelemetry/*` package updates including:
    - `instrumentation-aws-sdk`: drop instrumentation for AWS SDK **v2**
    - `instrumentation-express`: adds support for instrumenting express@5