### PR TITLE
Add missing file hook.mjs to published package

### DIFF
--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -36,7 +36,8 @@
     "README.md",
     "import.mjs",
     "package.json",
-    "require.js"
+    "require.js",
+    "hook.mjs"
   ],
   "scripts": {
     "clean": "rm -rf node_modules test/fixtures/a-ts-proj/node_modules test/fixtures/an-esm-pkg/{build,node_modules}",


### PR DESCRIPTION
Installing and importing `@elastic/opentelemetry-node` in a project raises this error on startup:

```
npm install && npm run build && npm run start

node:internal/modules/run_main:104
    triggerUncaughtException(
    ^
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/joshmock/Code/mcp-server-elasticsearch/node_modules/@elastic/opentelemetry-node/hook.mjs' imported from /home/joshmock/Code/mcp-server-elasticsearch/node_modules/@elastic/opentelemetry-node/import.mjs
    at finalizeResolution (node:internal/modules/esm/resolve:275:11)
    at moduleResolve (node:internal/modules/esm/resolve:860:10)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at nextResolve (node:internal/modules/esm/hooks:748:28)
    at Hooks.resolve (node:internal/modules/esm/hooks:240:30)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:685:35)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:305:38)
    at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:643:36)
    at TracingChannel.tracePromise (node:diagnostics_channel:344:14)
    at ModuleLoader.import (node:internal/modules/esm/loader:642:21) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///home/joshmock/Code/mcp-server-elasticsearch/node_modules/@elastic/opentelemetry-node/hook.mjs'
}

Node.js v23.11.0
```

It appears hook.mjs was recently added to the project and loads by default, but it is not included in the package when published to npm.
