### PR TITLE
release @elastic/opentelemetry-node@1.1.1

### DIFF
--- a/packages/opentelemetry-node/CHANGELOG.md
+++ b/packages/opentelemetry-node/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @elastic/opentelemetry-node Changelog
 
+## v1.1.1
+
+- Fix publishing so that the "hook.mjs" file is included.
+  (https://github.com/elastic/elastic-otel-node/pull/835)
+
+  Without this fix, using `node --import @elastic/opentelemetry-node ...` will
+  crash with:
+
+        Cannot find module '.../node_modules/@elastic/opentelemetry-node/hook.mjs' imported from .../node_modules/@elastic/opentelemetry-node/import.mjs
+
 ## v1.1.0
 
 - **BREAKING CHANGE**: This includes an update to `@opentelemetry/instrumentation-aws-sdk`

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-node",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/opentelemetry-instrumentation-openai": "^0.5.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "commonjs",
   "description": "Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js)",
   "publishConfig": {


### PR DESCRIPTION
v1.1.0 was a broken release because "hook.mjs" was not included in the published package (Fixed by https://github.com/elastic/elastic-otel-node/pull/835)