### PR TITLE
fix(otel-node): Move @opentelemetry/api to prod dependencies

### DIFF
--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/opentelemetry-instrumentation-openai": "^0.5.0",
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.202.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.202.0",
@@ -81,7 +82,6 @@
         "@grpc/grpc-js": "^1.11.1",
         "@grpc/proto-loader": "^0.7.13",
         "@hapi/hapi": "^21.3.10",
-        "@opentelemetry/api": ">=1.3.0 <1.10.0",
         "@types/tape": "^5.6.4",
         "amqplib": "^0.10.5",
         "bunyan": "^1.8.15",
@@ -2139,6 +2139,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
       }

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@elastic/opentelemetry-instrumentation-openai": "^0.5.0",
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-logs-otlp-grpc": "^0.202.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.202.0",
@@ -143,7 +144,6 @@
     "@grpc/grpc-js": "^1.11.1",
     "@grpc/proto-loader": "^0.7.13",
     "@hapi/hapi": "^21.3.10",
-    "@opentelemetry/api": ">=1.3.0 <1.10.0",
     "@types/tape": "^5.6.4",
     "amqplib": "^0.10.5",
     "bunyan": "^1.8.15",


### PR DESCRIPTION
Fix for https://github.com/elastic/elastic-otel-node/issues/846

I dunno if you guys have some other stuff to add to this