### PR TITLE
release @elastic/opentelemetry-instrumentation-openai 0.5.1

### DIFF
--- a/packages/instrumentation-openai/CHANGELOG.md
+++ b/packages/instrumentation-openai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @elastic/opentelemetry-instrumentation-openai Changelog
 
+## v0.5.1
+
+- Update OpenTelemetry JS dependencies to latest.
+
 ## v0.5.0
 
 - Update to [OpenTelemetry JS SDK 2.0](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md).

--- a/packages/instrumentation-openai/package-lock.json
+++ b/packages/instrumentation-openai/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-instrumentation-openai",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-instrumentation-openai",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "^0.203.0",

--- a/packages/instrumentation-openai/package.json
+++ b/packages/instrumentation-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-instrumentation-openai",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OpenTelemetry instrumentation for the `openai` OpenAI client library",
   "type": "commonjs",
   "publishConfig": {


### PR DESCRIPTION
THis release is just to bump upstream otel deps, so that they align with the deps used by other instrumentations included in EDOT Node.js.