### PR TITLE
release mockopampserver 0.4.0

### DIFF
--- a/packages/mockopampserver/CHANGELOG.md
+++ b/packages/mockopampserver/CHANGELOG.md
@@ -1,7 +1,8 @@
 # @elastic/mockopampserver Changelog
 
-## Unreleased
+## v0.4.0
 
+- Expose `MockOpAMPServer#setAgentConfigMap(...)` method, for use in testing.
 - chore: Excluding devDeps from Docker images should make them smaller.
 - Fix an issue where Ctrl+C would not exit mockopampserver *when running the Docker image*.
 

--- a/packages/mockopampserver/lib/mockopampserver.js
+++ b/packages/mockopampserver/lib/mockopampserver.js
@@ -184,7 +184,7 @@ class MockOpAMPServer {
         this._port = opts.port ?? DEFAULT_PORT;
         this._endpointPath = DEFAULT_ENDPOINT_PATH;
         if (opts.agentConfigMap) {
-            this._setAgentConfigMap(opts.agentConfigMap);
+            this.setAgentConfigMap(opts.agentConfigMap);
         }
         this._server = http.createServer(this._onRequest.bind(this));
         this._started = false;
@@ -210,7 +210,32 @@ class MockOpAMPServer {
         }
     }
 
-    _setAgentConfigMap(agentConfigMap) {
+    /**
+     * Set the data used by the server to provide `remoteConfig` to agents.
+     *
+     * `agentConfigMap` is of the form:
+     *      {
+     *          configMap: {
+     *              // Zero or more entries in `configMap`.
+     *              'some-key': {
+     *                  body: <Uint8Array of config file content>,
+     *                  contentType: <string>
+     *              }
+     *          }
+     *      }
+     *
+     * Example usage:
+     *      const config = { deactivate_all_instrumentations: 'true' };
+     *      opampServer.setAgentConfigMap({
+     *        configMap: {
+     *          elastic: {
+     *            body: Buffer.from(JSON.stringify(config), 'utf8'),
+     *            contentType: 'application/json',
+     *          }
+     *        }
+     *      });
+     */
+    setAgentConfigMap(agentConfigMap) {
         this._agentConfigMap = agentConfigMap;
         this._agentConfigMapHash = hashAgentConfigMap(agentConfigMap);
     }
@@ -362,7 +387,7 @@ class MockOpAMPServer {
         let agentConfigMap = {configMap: {}};
         const finish = () => {
             log.trace({agentConfigMap}, 'SetAgentConfigMap');
-            this._setAgentConfigMap(agentConfigMap);
+            this.setAgentConfigMap(agentConfigMap);
             res.writeHead(204);
             res.end();
             log.debug({req, res}, 'test API request: SetAgentConfigMap');

--- a/packages/mockopampserver/package-lock.json
+++ b/packages/mockopampserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/mockopampserver",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/mockopampserver",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",

--- a/packages/mockopampserver/package.json
+++ b/packages/mockopampserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/mockopampserver",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "commonjs",
   "description": "A mock OpAMP server, useful for dev and testing",
   "publishConfig": {


### PR DESCRIPTION
Also expose 'MockOpAMPServer#setAgentConfigMap(...)' method for use in testing.
This is needed for https://github.com/elastic/elastic-otel-node/pull/886 testing.
