### PR TITLE
chore: switch from dependency-check to knip for lint:deps

### DIFF
--- a/packages/opentelemetry-node/knip.jsonc
+++ b/packages/opentelemetry-node/knip.jsonc
@@ -1,0 +1,24 @@
+// https://knip.dev/reference/configuration
+{
+  "$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
+  "entry": [
+    "test/**/*.test.js",
+    "test/fixtures/*.js",
+  ],
+  "ignoreDependencies": [
+    "@opentelemetry/exporter-logs-.+",
+    "@opentelemetry/exporter-metrics-.+",
+    "@opentelemetry/winston-transport",
+    // Currently only used for JS doc types in lib/instrumentations.js.
+    "@opentelemetry/instrumentation",
+    // Currently only used for JS doc types in test/testutils.js.
+    "@opentelemetry/api-logs",
+  ],
+  "ignoreBinaries": ["eslint", "diff"],
+  "project": [
+    "lib/**/*.js",
+    "test/**/*.js",
+    "!test/fixtures/a-ts-proj",
+    "!test/fixtures/an-esm-pkg"
+  ]
+}

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -47,7 +47,7 @@
     "lint:eslint": "eslint --ext=js,mjs,cjs . # requires node >=16.0.0",
     "lint:types": "rm -rf build/lint-types && tsc --outDir build/lint-types && diff -ur types build/lint-types",
     "lint:fix": "eslint --ext=js,mjs,cjs --fix . # requires node >=16.0.0",
-    "lint:deps": "dependency-check require.js import.mjs 'lib/**/*.js' 'test/**/*.js' '!test/fixtures/a-ts-proj' '!test/fixtures/an-esm-pkg' -e mjs:../../scripts/parse-mjs-source -i @types/tape -i dotenv -i @opentelemetry/winston-transport -i @opentelemetry/exporter-logs-* -i @opentelemetry/exporter-metrics-*",
+    "lint:deps": "npx --yes knip@5.61.3 --dependencies",
     "lint:license-files": "../../scripts/gen-notice.sh --lint .  # requires node >=16",
     "lint:changelog": "../../scripts/extract-release-notes.js .",
     "test": "NODE_OPTIONS='-r dotenv/config' DOTENV_CONFIG_PATH=./test/test-services.env tape test/**/*.test.js",


### PR DESCRIPTION
Recently I had to avoid using the `||=` JS syntax to not break
dependency-check (used for 'npm run lint:deps'). That's lame.
https://github.com/elastic/elastic-otel-node/pull/886/commits/4a77a0ba28717c0ff7161bbbbf8f6bb860c4b1cf

`dependency-check` is deprecated: https://www.npmjs.com/package/dependency-check
We could consider using `knip`. FWIW opentelemetry-js-contrib is using
it.

Here I've chosen to not install knip as a devDep, though we could
consider doing so. I avoided it because `npm init @knip/config`
**installs TypeScript**, which felt a bit overkill to me. We already
have TS at the top-level, so perhaps not bad to add it.


# checklist

- [ ] Discuss with David.
- [ ] See about installing knip at the top-level.
- [ ] Switch the other packages to knip as well.