### PR TITLE
chore(opamp-client-node): ignore undici >=7 for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # Packages whose major versions have dropped support for Node.js versions
+      # that this package needs.
+      - dependency-name: "undici" # undici@7 dropped 18
+        versions: [ ">=7" ]
     groups:
       opamp-client-node:
         patterns:


### PR DESCRIPTION
undici@7 dropped node 18 support, but this package still supports it

Refs: https://github.com/elastic/elastic-otel-node/pull/911
