### PR TITLE
feat(mockotlpserver): 'spacer' printer to help view the output slightly

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- feat: Add a 'spacer' printer, and add it to the default set.
+  This will print a blank line if it has been a "while" (currently 1s) since
+  the last printed output. This helps in viewing the printed output.
+  E.g. `node lib/cli.js -o summary,spacer`.
+
 - chore: Excluding devDeps from Docker images should make them smaller.
 
 ## v0.8.0

--- a/packages/mockotlpserver/lib/cli.js
+++ b/packages/mockotlpserver/lib/cli.js
@@ -13,7 +13,12 @@ const os = require('os');
 const dashdash = require('dashdash');
 
 const luggite = require('./luggite');
-const {JSONPrinter, InspectPrinter, FilePrinter} = require('./printers');
+const {
+    JSONPrinter,
+    InspectPrinter,
+    FilePrinter,
+    SpacerPrinter,
+} = require('./printers');
 const {TraceWaterfallPrinter} = require('./waterfall');
 const {MetricsSummaryPrinter} = require('./metrics-summary');
 const {LogsSummaryPrinter} = require('./logs-summary');
@@ -40,6 +45,7 @@ const PRINTER_NAMES = [
     'logs-summary',
     'summary',
 
+    'spacer', // print a blank line between printed outputs separated by a time gap
     'trace-file', // saving into fs for UI and other processing
 ];
 
@@ -91,9 +97,9 @@ const OPTIONS = [
     {
         names: ['o'],
         type: 'arrayOfPrinters',
-        help: `Output formats for printing OTLP data. Comma-separated, one or more of "${PRINTER_NAMES.join(
-            '", "'
-        )}". Default: "inspect,summary"`,
+        help: `Output formats for printing OTLP data. Comma-separated, one or more of: ${PRINTER_NAMES.join(
+            ', '
+        )}. Default: "inspect,summary,spacer".`,
     },
     {
         names: ['hostname'],
@@ -139,7 +145,7 @@ async function main() {
         // The way dashdash `--help` output prints the default of an array is
         // misleading, so we'll apply the default here and manually document
         // the default in the "help:" string above.
-        opts.o = ['inspect', 'summary'];
+        opts.o = ['inspect', 'summary', 'spacer'];
     }
 
     /** @type {Array<'http'|'grpc'|'ui'>} */
@@ -222,6 +228,9 @@ async function main() {
                 printers.push(new LogsSummaryPrinter(log));
                 break;
 
+            case 'spacer':
+                printers.push(new SpacerPrinter(log));
+                break;
             case 'trace-file':
                 printers.push(new FilePrinter(log));
                 break;

--- a/packages/mockotlpserver/lib/printers.js
+++ b/packages/mockotlpserver/lib/printers.js
@@ -196,9 +196,39 @@ class FilePrinter extends Printer {
     }
 }
 
+/**
+ * If there has been a `_timeGap` since the last printable-event, then print
+ * a blank line in the console output to provide some visual spacing. This
+ * makes the printed output easier to reason about.
+ */
+class SpacerPrinter extends Printer {
+    constructor(log) {
+        super(log);
+        this._lastPrintTime = Date.now();
+        this._timeGap = 1000;
+    }
+    _handleGap() {
+        const now = Date.now();
+        if (now - this._lastPrintTime > this._timeGap) {
+            console.log(); // blank line spacing between earlier group
+        }
+        this._lastPrintTime = now;
+    }
+    printTrace(_) {
+        this._handleGap();
+    }
+    printMetrics(_) {
+        this._handleGap();
+    }
+    printLogs(_) {
+        this._handleGap();
+    }
+}
+
 module.exports = {
     Printer,
     JSONPrinter,
     InspectPrinter,
     FilePrinter,
+    SpacerPrinter,
 };


### PR DESCRIPTION
So, for example, if I'm running mockotlpserver like this:

```
node lib/cli.js -o summary,spacer
```

and then run something that generates some telemetry like this (side note: the envvars I'm setting here are to reduce some of the noise from so many metrics being generated by default):

```
cd .../elastic-otel-node/examples

OTEL_NODE_DISABLED_INSTRUMENTATIONS=dns,net,runtime-node ELASTIC_OTEL_HOST_METRICS_DISABLED=true ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING=true node --import @elastic/opentelemetry-node bunyan-logging-app.mjs

OTEL_NODE_DISABLED_INSTRUMENTATIONS=dns,net,runtime-node ELASTIC_OTEL_HOST_METRICS_DISABLED=true ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING=true node --import @elastic/opentelemetry-node bunyan-logging-app.mjs
```

Now the mockotlpserver output will look like:

```
------ logs (2 records) ------
[2025-08-14T16:08:31.766000244Z] info/SEV-9 (unknown_service:node): hi there
    name: 'bunyan-logging-app',
    foo: 'bar'
[2025-08-14T16:08:31.767000000Z] info/SEV-9 (unknown_service:node, traceId=4438ed, spanId=8c6366): inside a span
    name: 'bunyan-logging-app'
------ trace 4438ed (1 span) ------
       span 8c6366 "manual-span" (0.3ms, SPAN_KIND_INTERNAL, service.name=unknown_service:node, scope=example)

------ logs (2 records) ------
[2025-08-14T16:08:33.852000000Z] info/SEV-9 (unknown_service:node): hi there
    name: 'bunyan-logging-app',
    foo: 'bar'
[2025-08-14T16:08:33.852000000Z] info/SEV-9 (unknown_service:node, traceId=77c08e, spanId=82f65d): inside a span
    name: 'bunyan-logging-app'
------ trace 77c08e (1 span) ------
       span 82f65d "manual-span" (0.3ms, SPAN_KIND_INTERNAL, service.name=unknown_service:node, scope=example)
```

**That blank line** between the telemetry for the two invocations of `node bunyan-logging-app.mjs` is what this new SpacerPrinter is doing. It helps read the output.