### PR TITLE
feat(mockotlpserver): add a log.debug for incoming http and grpc requests

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - chore: Excluding devDeps from Docker images should make them smaller.
 
+- feat: Adds a log.debug() for every incoming HTTP and gRPC request.
+
 ## v0.8.0
 
 - feat: 'summary' rendering of Sum and Gauge metric types

--- a/packages/mockotlpserver/lib/grpc.js
+++ b/packages/mockotlpserver/lib/grpc.js
@@ -47,6 +47,29 @@ for (const [name, path] of Object.entries(packages)) {
 
 // helper functions
 
+/**
+ * Creates a gRPC server interceptor to log incoming requests.
+ *
+ * @returns {grpc.ServerInterceptor}
+ */
+function createLoggingInterceptor(log) {
+    return (methDesc, call) => {
+        return new grpc.ServerInterceptingCall(call, {
+            start: (next) => {
+                next({
+                    onReceiveMetadata: (metadata, mdNext) => {
+                        log.debug(
+                            {metadata},
+                            `incoming gRPC req: ${methDesc.path}`
+                        );
+                        mdNext(metadata);
+                    },
+                });
+            },
+        });
+    };
+}
+
 function intakeTraces(call, callback) {
     callback(null, {
         partial_success: {
@@ -80,13 +103,10 @@ function intakeLogs(call, callback) {
     diagchGet(CH_OTLP_V1_LOGS).publish(call.request);
 }
 
-// function intakeLogs(call, callback) {
-//   // TODO: check proto
-// }
-
 class GrpcService extends Service {
     /**
      * @param {Object} opts
+     * @param {import('./luggite').Logger} opts.log
      * @param {string} opts.hostname
      * @param {number} opts.port
      */
@@ -98,9 +118,11 @@ class GrpcService extends Service {
     }
 
     async start() {
-        const {hostname, port} = this._opts;
+        const {log, hostname, port} = this._opts;
 
-        this._grpcServer = new grpc.Server();
+        this._grpcServer = new grpc.Server({
+            interceptors: [createLoggingInterceptor(log)],
+        });
         this._grpcServer.addService(packages.trace.TraceService.service, {
             Export: intakeTraces,
         });

--- a/packages/mockotlpserver/lib/http.js
+++ b/packages/mockotlpserver/lib/http.js
@@ -155,6 +155,10 @@ class HttpService extends Service {
         const httpTunnel = tunnel && createHttpTunnel(log, tunnel);
 
         this._server = http.createServer((req, res) => {
+            log.debug(
+                {headers: req.headers},
+                `incoming HTTP req: ${req.method} ${req.url}`
+            );
             const isBrowserReq = isBrowserUserAgent(req.headers['user-agent']);
 
             // Accept CORS requests from browsers

--- a/packages/mockotlpserver/lib/mockotlpserver.js
+++ b/packages/mockotlpserver/lib/mockotlpserver.js
@@ -119,6 +119,7 @@ class MockOtlpServer {
                     // Handles `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`.
                     // NOTE: to debug read this: https://github.com/grpc/grpc-node/blob/master/TROUBLESHOOTING.md
                     this._grpcService = new GrpcService({
+                        log: this._log,
                         hostname: this._grpcHostname,
                         port: this._grpcPort,
                     });


### PR DESCRIPTION
This includes logging the headers/metadata which is useful for debugging
(e.g. knowing what user-agent is being sent).
