### PR TITLE
release mockotlpserver 0.9.0

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/mockotlpserver Changelog
 
-## Unreleased
+## v0.9.0
 
 - feat: Add a 'spacer' printer, and add it to the default set.
   This will print a blank line if it has been a "while" (currently 1s) since

--- a/packages/mockotlpserver/package-lock.json
+++ b/packages/mockotlpserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/mockotlpserver",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.11.1",

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "commonjs",
   "description": "A mock OTLP server, useful for dev and testing",
   "publishConfig": {


### PR DESCRIPTION
Two log.debug's and more blank lines in the output ([changelog](https://github.com/elastic/elastic-otel-node/blob/bda74d05319e2c37f28c005dea4d3be7a7a31c63/packages/mockotlpserver/CHANGELOG.md#unreleased))?! Best. Release. Evar.