### PR TITLE
mockotlpserver 0.10.0; support capturing incoming request data (like headers)

### DIFF
--- a/packages/mockotlpserver/CHANGELOG.md
+++ b/packages/mockotlpserver/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @elastic/mockotlpserver Changelog
 
+## v0.10.0
+
+- feat: Add a new `onRequest` callback option to `MockOTLPServer` that allows
+  capturing some info for each incoming request. The callback will be called
+  for each incoming OTLP request. The callback data will include:
+
+        {
+            transport: <string>,    // 'http' or 'grpc'
+            method?: <string>,      // HTTP method if transport is 'http'
+            path: <string>,         // HTTP or gRPC request path
+            headers: <map>,         // HTTP headers if transport is 'http'
+            metadata: <Metadata>,   // gRPC headers if transport is 'grpc'
+        }
+
 ## v0.9.0
 
 - feat: Add a 'spacer' printer, and add it to the default set.

--- a/packages/mockotlpserver/lib/diagch.js
+++ b/packages/mockotlpserver/lib/diagch.js
@@ -49,6 +49,8 @@ const CH_OTLP_V1_TRACE = 'otlp.v1.trace';
 const CH_OTLP_V1_METRICS = 'otlp.v1.metrics';
 const CH_OTLP_V1_LOGS = 'otlp.v1.logs';
 
+const CH_OTLP_V1_REQUEST = 'otlp.v1.request';
+
 module.exports = {
     diagchGet,
     diagchSub,
@@ -56,4 +58,5 @@ module.exports = {
     CH_OTLP_V1_TRACE,
     CH_OTLP_V1_METRICS,
     CH_OTLP_V1_LOGS,
+    CH_OTLP_V1_REQUEST,
 };

--- a/packages/mockotlpserver/lib/grpc.js
+++ b/packages/mockotlpserver/lib/grpc.js
@@ -13,8 +13,11 @@ const {
     CH_OTLP_V1_TRACE,
     CH_OTLP_V1_METRICS,
     CH_OTLP_V1_LOGS,
+    CH_OTLP_V1_REQUEST,
 } = require('./diagch');
 const {Service} = require('./service');
+
+const diagChReq = diagchGet(CH_OTLP_V1_REQUEST);
 
 // TODO: for now `proto` files are copied from
 // https://github.com/open-telemetry/opentelemetry-proto
@@ -62,6 +65,11 @@ function createLoggingInterceptor(log) {
                             {metadata},
                             `incoming gRPC req: ${methDesc.path}`
                         );
+                        diagChReq.publish({
+                            transport: 'grpc',
+                            path: methDesc.path,
+                            metadata: metadata,
+                        });
                         mdNext(metadata);
                     },
                 });

--- a/packages/mockotlpserver/lib/http.js
+++ b/packages/mockotlpserver/lib/http.js
@@ -10,6 +10,7 @@ const {
     CH_OTLP_V1_LOGS,
     CH_OTLP_V1_METRICS,
     CH_OTLP_V1_TRACE,
+    CH_OTLP_V1_REQUEST,
 } = require('./diagch');
 const {getProtoRoot} = require('./proto');
 const {Service} = require('./service');
@@ -27,6 +28,8 @@ const corsHeaders = {
     'Access-Control-Allow-Headers': '*',
     'Access-Control-Allow-Method': 'POST, OPTIONS',
 };
+
+const diagChReq = diagchGet(CH_OTLP_V1_REQUEST);
 
 function diagChFromReqUrl(reqUrl) {
     switch (reqUrl) {
@@ -180,6 +183,13 @@ class HttpService extends Service {
                     `unexpected request Content-Type: "${contentType}"`
                 );
             }
+
+            diagChReq.publish({
+                transport: 'http',
+                method: req.method,
+                path: req.url,
+                headers: req.headers,
+            });
 
             const chunks = [];
             req.on('data', (chunk) => chunks.push(chunk));

--- a/packages/mockotlpserver/lib/mockotlpserver.js
+++ b/packages/mockotlpserver/lib/mockotlpserver.js
@@ -41,6 +41,11 @@ class CallbackPrinter extends Printer {
             this._callbacks.onLogs(logs);
         }
     }
+    printRequest(req) {
+        if (this._callbacks.onRequest) {
+            this._callbacks.onRequest(req);
+        }
+    }
 }
 
 class MockOtlpServer {
@@ -60,9 +65,10 @@ class MockOtlpServer {
      * @param {string} [opts.tunnel] Default undefined.
      * @param {string} [opts.uiHostname] Default 'localhost'.
      * @param {number} [opts.uiPort] Default 8080. Use 0 to select a free port.
-     * @param {Function} [opts.onTrace] Called for each received trace service request.
-     * @param {Function} [opts.onMetrics] Called for each received metrics service request.
-     * @param {Function} [opts.onLogs] Called for each received logs service request.
+     * @param {Function} [opts.onTrace] Called for each completed trace service request.
+     * @param {Function} [opts.onMetrics] Called for each completed metrics service request.
+     * @param {Function} [opts.onLogs] Called for each completed logs service request.
+     * @param {Function} [opts.onRequest] Called for each received HTTP or gRPC request.
      */
     constructor(opts) {
         opts = opts ?? {};
@@ -83,6 +89,7 @@ class MockOtlpServer {
             onTrace: opts.onTrace,
             onMetrics: opts.onMetrics,
             onLogs: opts.onLogs,
+            onRequest: opts.onRequest,
         });
         this._printer.subscribe();
 

--- a/packages/mockotlpserver/lib/printers.js
+++ b/packages/mockotlpserver/lib/printers.js
@@ -20,6 +20,7 @@ const {
     CH_OTLP_V1_LOGS,
     CH_OTLP_V1_METRICS,
     CH_OTLP_V1_TRACE,
+    CH_OTLP_V1_REQUEST,
 } = require('./diagch');
 const {
     jsonStringifyLogs,
@@ -72,6 +73,18 @@ class Printer {
                     this._log.error(
                         {err},
                         `${inst.constructor.name}.printLogs() threw`
+                    );
+                }
+            });
+        }
+        if (typeof inst.printRequest === 'function') {
+            diagchSub(CH_OTLP_V1_REQUEST, (...args) => {
+                try {
+                    inst.printRequest(...args);
+                } catch (err) {
+                    this._log.error(
+                        {err},
+                        `${inst.constructor.name}.printRequest() threw`
                     );
                 }
             });

--- a/packages/mockotlpserver/package-lock.json
+++ b/packages/mockotlpserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/mockotlpserver",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.11.1",

--- a/packages/mockotlpserver/package.json
+++ b/packages/mockotlpserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/mockotlpserver",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "commonjs",
   "description": "A mock OTLP server, useful for dev and testing",
   "publishConfig": {


### PR DESCRIPTION
This is to be used to help test that OTLP exporter requests include
the expected User-Agent.

Refs: https://github.com/elastic/elastic-otel-node/issues/431
