### PR TITLE
feat(opentelemetry-node): add EDOT Node.js identifier to User-Agent header for 'http'-flavour OTLP exports

### DIFF
--- a/packages/mockotlpserver/lib/diagch.js
+++ b/packages/mockotlpserver/lib/diagch.js
@@ -49,6 +49,8 @@ const CH_OTLP_V1_TRACE = 'otlp.v1.trace';
 const CH_OTLP_V1_METRICS = 'otlp.v1.metrics';
 const CH_OTLP_V1_LOGS = 'otlp.v1.logs';
 
+const CH_OTLP_V1_REQUEST = 'otlp.v1.request';
+
 module.exports = {
     diagchGet,
     diagchSub,
@@ -56,4 +58,5 @@ module.exports = {
     CH_OTLP_V1_TRACE,
     CH_OTLP_V1_METRICS,
     CH_OTLP_V1_LOGS,
+    CH_OTLP_V1_REQUEST,
 };

--- a/packages/mockotlpserver/lib/grpc.js
+++ b/packages/mockotlpserver/lib/grpc.js
@@ -13,8 +13,11 @@ const {
     CH_OTLP_V1_TRACE,
     CH_OTLP_V1_METRICS,
     CH_OTLP_V1_LOGS,
+    CH_OTLP_V1_REQUEST,
 } = require('./diagch');
 const {Service} = require('./service');
+
+const diagChReq = diagchGet(CH_OTLP_V1_REQUEST);
 
 // TODO: for now `proto` files are copied from
 // https://github.com/open-telemetry/opentelemetry-proto
@@ -62,6 +65,11 @@ function createLoggingInterceptor(log) {
                             {metadata},
                             `incoming gRPC req: ${methDesc.path}`
                         );
+                        diagChReq.publish({
+                            transport: 'grpc',
+                            path: methDesc.path,
+                            metadata: metadata,
+                        });
                         mdNext(metadata);
                     },
                 });

--- a/packages/mockotlpserver/lib/http.js
+++ b/packages/mockotlpserver/lib/http.js
@@ -10,6 +10,7 @@ const {
     CH_OTLP_V1_LOGS,
     CH_OTLP_V1_METRICS,
     CH_OTLP_V1_TRACE,
+    CH_OTLP_V1_REQUEST,
 } = require('./diagch');
 const {getProtoRoot} = require('./proto');
 const {Service} = require('./service');
@@ -27,6 +28,8 @@ const corsHeaders = {
     'Access-Control-Allow-Headers': '*',
     'Access-Control-Allow-Method': 'POST, OPTIONS',
 };
+
+const diagChReq = diagchGet(CH_OTLP_V1_REQUEST);
 
 function diagChFromReqUrl(reqUrl) {
     switch (reqUrl) {
@@ -180,6 +183,13 @@ class HttpService extends Service {
                     `unexpected request Content-Type: "${contentType}"`
                 );
             }
+
+            diagChReq.publish({
+                transport: 'http',
+                method: req.method,
+                path: req.url,
+                headers: req.headers,
+            });
 
             const chunks = [];
             req.on('data', (chunk) => chunks.push(chunk));

--- a/packages/mockotlpserver/lib/mockotlpserver.js
+++ b/packages/mockotlpserver/lib/mockotlpserver.js
@@ -41,6 +41,11 @@ class CallbackPrinter extends Printer {
             this._callbacks.onLogs(logs);
         }
     }
+    printRequest(req) {
+        if (this._callbacks.onRequest) {
+            this._callbacks.onRequest(req);
+        }
+    }
 }
 
 class MockOtlpServer {
@@ -60,9 +65,10 @@ class MockOtlpServer {
      * @param {string} [opts.tunnel] Default undefined.
      * @param {string} [opts.uiHostname] Default 'localhost'.
      * @param {number} [opts.uiPort] Default 8080. Use 0 to select a free port.
-     * @param {Function} [opts.onTrace] Called for each received trace service request.
-     * @param {Function} [opts.onMetrics] Called for each received metrics service request.
-     * @param {Function} [opts.onLogs] Called for each received logs service request.
+     * @param {Function} [opts.onTrace] Called for each completed trace service request.
+     * @param {Function} [opts.onMetrics] Called for each completed metrics service request.
+     * @param {Function} [opts.onLogs] Called for each completed logs service request.
+     * @param {Function} [opts.onRequest] Called for each received HTTP or gRPC request.
      */
     constructor(opts) {
         opts = opts ?? {};
@@ -83,6 +89,7 @@ class MockOtlpServer {
             onTrace: opts.onTrace,
             onMetrics: opts.onMetrics,
             onLogs: opts.onLogs,
+            onRequest: opts.onRequest,
         });
         this._printer.subscribe();
 

--- a/packages/mockotlpserver/lib/printers.js
+++ b/packages/mockotlpserver/lib/printers.js
@@ -20,6 +20,7 @@ const {
     CH_OTLP_V1_LOGS,
     CH_OTLP_V1_METRICS,
     CH_OTLP_V1_TRACE,
+    CH_OTLP_V1_REQUEST,
 } = require('./diagch');
 const {
     jsonStringifyLogs,
@@ -72,6 +73,18 @@ class Printer {
                     this._log.error(
                         {err},
                         `${inst.constructor.name}.printLogs() threw`
+                    );
+                }
+            });
+        }
+        if (typeof inst.printRequest === 'function') {
+            diagchSub(CH_OTLP_V1_REQUEST, (...args) => {
+                try {
+                    inst.printRequest(...args);
+                } catch (err) {
+                    this._log.error(
+                        {err},
+                        `${inst.constructor.name}.printRequest() threw`
                     );
                 }
             });

--- a/packages/opentelemetry-node/lib/dynconf.js
+++ b/packages/opentelemetry-node/lib/dynconf.js
@@ -10,6 +10,7 @@ const {channel, subscribe, unsubscribe} = require('diagnostics_channel');
 const {ExportResultCode} = require('@opentelemetry/core');
 
 const {log} = require('./logging');
+const {setUserAgentOnOTLPTransport} = require('./user-agent');
 
 /**
  * @typedef {import('@opentelemetry/sdk-trace-base').SpanExporter} SpanExporter
@@ -52,6 +53,7 @@ class DynConfSpanExporter {
         this._enabled = true;
         this._boundSub = this._onChange.bind(this); // save for unsubscribe()
         subscribe(CH_SPAN_EXPORTERS, this._boundSub);
+        setUserAgentOnOTLPTransport(this._delegate?._delegate?._transport);
     }
     /**
      * @param {DynConfSpanExportersEvent} chEvent
@@ -176,6 +178,7 @@ class DynConfMetricExporter {
         this._enabled = true;
         this._boundSub = this._onChange.bind(this); // save for unsubscribe()
         subscribe(CH_METRIC_EXPORTERS, this._boundSub);
+        setUserAgentOnOTLPTransport(this._delegate?._delegate?._transport);
     }
     /**
      * @param {DynConfMetricExportersEvent} chEvent
@@ -271,6 +274,7 @@ class DynConfLogRecordExporter {
         this._enabled = true;
         this._boundSub = this._onChange.bind(this); // save for unsubscribe()
         subscribe(CH_LOG_RECORD_EXPORTERS, this._boundSub);
+        setUserAgentOnOTLPTransport(this._delegate?._delegate?._transport);
     }
     /**
      * @param {DynConfLogRecordExportersEvent} chEvent

--- a/packages/opentelemetry-node/lib/user-agent.js
+++ b/packages/opentelemetry-node/lib/user-agent.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Setting the User-Agent for exporters created by EDOT Node.js.
+//
+// Eventually the upstream exporters will support an option for this
+// (see https://github.com/elastic/elastic-otel-node/issues/431). The
+// monkey-patching done in this file are a temporary measure.
+
+const {log} = require('./logging');
+
+const VERSION = require('../package.json').version;
+const EDOT_USER_AGENT_HTTP = `elastic-otlp-http-javascript/${VERSION}`;
+// const EDOT_USER_AGENT_GRPC = `elastic-otlp-grpc-javascript/${VERSION}`;
+
+function setUserAgentOnOTLPTransport(transport) {
+    if (!transport) {
+        log.debug(
+            `cannot set an Elastic User-Agent on "${this._delegate.constructor.name}" span exporter`
+        );
+        return;
+    }
+    switch (transport.constructor.name) {
+        case 'RetryingTransport': {
+            // HTTP:
+            // OTLPTraceExporter {
+            //   _delegate: OTLPExportDelegate {
+            //     _transport: RetryingTransport {
+            //       _transport: [HttpExporterTransport]
+            const httpReqParams = transport._transport?._parameters;
+            if (typeof httpReqParams?.headers === 'function') {
+                const headersFn = httpReqParams.headers;
+                httpReqParams.headers = () => {
+                    const hdrs = headersFn();
+                    hdrs['User-Agent'] =
+                        `${EDOT_USER_AGENT_HTTP} ${hdrs['User-Agent']}`.trimEnd();
+                    return hdrs;
+                };
+            }
+            break;
+        }
+
+        // This overriding metadata is insufficient, because grpc-js
+        // overwrites metadata['User-Agent'] from client options.
+        // TODO: upstream PR for otlp-grpc-exporter-base to allow setting `grpc.primary_user_agent` and/or `grpc.secondary_user_agent` client options.
+        // case 'GrpcExporterTransport': {
+        //     // gRPC:
+        //     // OTLPTraceExporter {
+        //     //   _delegate: OTLPExportDelegate {
+        //     //     _transport: GrpcExporterTransport {
+        //     const metadataFn = transport._parameters?.metadata;
+        //     if (typeof metadataFn === 'function') {
+        //         transport._parameters.metadata = () => {
+        //             /** @type {import('@grpc/grpc-js').Metadata} */
+        //             const md = metadataFn();
+        //             md.set('User-Agent', EDOT_USER_AGENT_GRPC);
+        //             return md;
+        //         };
+        //     }
+        //     break;
+        // }
+
+        default:
+            log.debug(
+                `cannot set an Elastic User-Agent on "${transport.constructor.name}" transport class`
+            );
+    }
+}
+
+module.exports = {
+    setUserAgentOnOTLPTransport,
+};

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -41,7 +41,7 @@
   ],
   "scripts": {
     "clean": "rm -rf node_modules test/fixtures/a-ts-proj/node_modules test/fixtures/an-esm-pkg/{build,node_modules}",
-    "dev:use-local-deps": "npm install --no-save ../opamp-client-node ../mockopampserver",
+    "dev:use-local-deps": "npm install --no-save ../mockotlpserver ../opamp-client-node ../mockopampserver",
     "example": "cd ../../examples && node --import @elastic/opentelemetry-node simple-http-request.js",
     "lint": "npm run lint:eslint && npm run lint:types && npm run lint:deps && npm run lint:license-files && npm run lint:changelog",
     "lint:eslint": "eslint --ext=js,mjs,cjs . # requires node >=16.0.0",

--- a/packages/opentelemetry-node/test/OTEL_NODE_RESOURCE_DETECTORS.test.js
+++ b/packages/opentelemetry-node/test/OTEL_NODE_RESOURCE_DETECTORS.test.js
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Test that `User-Agent` is properly set into `OTEL_EXPORTER_OTLP_*_HEADERS`
-// environment vars if not defined.
-
 const {test} = require('tape');
 const {runTestFixtures} = require('./testutils');
 

--- a/packages/opentelemetry-node/test/fixtures/use-all-the-signals.js
+++ b/packages/opentelemetry-node/test/fixtures/use-all-the-signals.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Usage:
+// ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING=true node -r @elastic/opentelemetry-node use-all-the-signals.js
+
+const http = require('http');
+const bunyan = require('bunyan');
+
+const log = bunyan.createLogger({name: 'use-all-the-signals'});
+http.get('http://www.google.com/', (res) => {
+    log.info(
+        {statusCode: res.statusCode, headers: res.headers},
+        'client response'
+    );
+    res.resume();
+    res.on('end', () => {
+        log.info('client response: end');
+    });
+});

--- a/packages/opentelemetry-node/test/user-agent.test.js
+++ b/packages/opentelemetry-node/test/user-agent.test.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Test that the 'User-Agent' in exporter requests is set to include to
+// mention EDOT Node.js.
+
+const test = require('tape');
+const {runTestFixtures} = require('./testutils');
+
+const otlpProtocols = ['http/protobuf', 'http/json', 'grpc'];
+
+/** @type {import('./testutils').TestFixture[]} */
+const testFixtures = otlpProtocols.map((otlpProtocol) => {
+    return {
+        name: otlpProtocol,
+        otlpProtocol,
+
+        args: ['./fixtures/use-all-the-signals.js'],
+        cwd: __dirname,
+        env: {
+            NODE_OPTIONS: '--import=@elastic/opentelemetry-node',
+        },
+        // verbose: true,
+        checkTelemetry: (t, col) => {
+            t.ok(col.rawRequests.length > 1);
+            col.rawRequests.forEach((req) => {
+                switch (req.transport) {
+                    case 'http':
+                        t.ok(
+                            req.headers['user-agent'].includes(
+                                'elastic-otlp-http-javascript/'
+                            ),
+                            'User-Agent header includes EDOT Node.js string'
+                        );
+                        break;
+
+                    case 'grpc':
+                        // TODO: assert this when user-agent override for gRPC is implemented
+                        t.skip(
+                            req.metadata
+                                .get('user-agent')
+                                .includes('elastic-otlp-grpc-javascript/'),
+                            'User-Agent header includes EDOT Node.js string'
+                        );
+                        break;
+                }
+            });
+        },
+    };
+});
+
+test('User-Agent', (suite) => {
+    runTestFixtures(suite, testFixtures);
+    suite.end();
+});


### PR DESCRIPTION
This is a temporary workaround until upstream exporters support providing
a string to add to the User-Agent header for exports. Currently this
only works for the HTTP-flavours of OTLP (i.e. not for gRPC).

Refs: https://github.com/elastic/elastic-otel-node/issues/431
