### PR TITLE
chore(instrumention-openai): don't update @types/glob version to 9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
       # that this package needs.
       - dependency-name: "undici" # undici@7 dropped 18
         versions: [ ">=7" ]
+      - dependency-name: "@types/glob" # @types/glob@9 is empty, assumes using glob@9, but we aren't
+        versions: [ ">=9" ]
     groups:
       opentelemetry:
         patterns:


### PR DESCRIPTION
It drops its types, assuming one is using glob@9, but we are not
because transitive deps.

Refs: https://github.com/elastic/elastic-otel-node/pull/985 (this is why this deps PR is failing tests)
