### PR TITLE
chore: pin to uuid@11 because uuid@12 dropped commonjs support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # uuid@12 dropped CommonJS support (https://github.com/uuidjs/uuid/issues/881)
+      - dependency-name: "uuid"
+        versions: [ ">=12" ]
     groups:
       mockopampserver:
         patterns:
@@ -61,10 +65,12 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     ignore:
-      # Packages whose major versions have dropped support for Node.js versions
-      # that this package needs.
-      - dependency-name: "undici" # undici@7 dropped 18
+      # undici@7 dropped Node.js 18 support
+      - dependency-name: "undici"
         versions: [ ">=7" ]
+      # uuid@12 dropped CommonJS support (https://github.com/uuidjs/uuid/issues/881)
+      - dependency-name: "uuid"
+        versions: [ ">=12" ]
     groups:
       opamp-client-node:
         patterns:


### PR DESCRIPTION
This is why this two dependabot PRs were failing:
https://github.com/elastic/elastic-otel-node/pull/1002
https://github.com/elastic/elastic-otel-node/pull/1001
