### PR TITLE
chore(instrumentation-openai): ignore @types/glob >=9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,9 @@ updates:
       # Do not yet support openai@5.
       - dependency-name: "openai"
         versions: [ ">=5" ]
+      # @types/glob@9 is empty, assumes using glob@9, but we aren't
+      - dependency-name: "@types/glob"
+        versions: [ ">=9" ]
     groups:
       instrumentation-openai:
         patterns:


### PR DESCRIPTION
@types/glob@9 dropped its types, assuming users are also using
glob@9 (which ships its own types now). However, we are using glob
via transitive deps, and not version 9.

Refs: https://github.com/elastic/elastic-otel-node/pull/989 (same thing in opentelemetry-node pkg)
