### PR TITLE
chore: update deps in /examples all in one go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -127,10 +127,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    groups:
-      opentelemetry:
-        patterns:
-        - "@opentelemetry/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Before this change we'd get separate dependabot updates for
EDOT Node.js and the directly otel deps. That results in large
churn in package-lock because those packages share so many
otel transitive deps.

Refs: https://github.com/elastic/elastic-otel-node/pull/1023
Refs: https://github.com/elastic/elastic-otel-node/pull/1022
