### PR TITLE
Add docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 tmp
 /packages/mockotlpserver/db
 docs/.artifacts
+.artifacts

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -2,9 +2,13 @@ project: 'EDOT Node.js release notes'
 cross_links:
   - docs-content
   - opentelemetry
+  - elastic-agent
+  - apm-agent-nodejs
 toc:
   - toc: release-notes
+  - toc: reference
 subs:
+  motlp: Elastic Cloud Managed OTLP Endpoint
   edot:    "Elastic Distribution of OpenTelemetry"
   ecloud:   "Elastic Cloud"
   ech:   "Elastic Cloud Hosted"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,272 @@
+---
+navigation_title: Configuration
+description: How to configure the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js) using environment variables.
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_node: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Configure the EDOT Node.js SDK
+
+The {{edot}} Node.js (EDOT Node.js) is configured with environment variables beginning with `OTEL_` or `ELASTIC_OTEL_`. Any `OTEL_*` environment variables behave the same as with the OpenTelemetry SDK. For example, all the OpenTelemetry [General SDK Configuration env vars](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) are supported. If EDOT Node.js provides a configuration setting specific to the Elastic distribution, it will begin with `ELASTIC_OTEL_`.
+
+
+## Basic configuration
+
+If not configured, EDOT Node.js will send telemetry data to `http://localhost:4318` with no authentication information, and identify the running service as `unknown_service:node`. Typically a minimal configuration will include
+
+* `OTEL_EXPORTER_OTLP_ENDPOINT`: The full URL of an OpenTelemetry Collector where data will be sent.
+* `OTEL_EXPORTER_OTLP_HEADERS`: A comma-separated list of HTTP headers used for exporting data, typically used to set the `Authorization` header with auth information.
+* `OTEL_SERVICE_NAME`: The name of your service, used to distinguish telemetry data from other services in your system.
+
+For example, when using an {{serverless-full}} deployment this might be:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://my-deployment-abc123.ingest.us-west-2.aws.elastic.cloud"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey Zm9vO...mJhcg=="
+export OTEL_SERVICE_NAME=my-app
+```
+
+
+## Configuration reference
+
+This section attempts to list all environment variables that can be used to configure EDOT Node.js. Some settings also have a section below discussing behavior that is interesting and/or specific to EDOT Node.js.
+
+:::{warning}
+The behavior of `OTEL_` environment variables are typically defined by OpenTelemetry dependencies of EDOT Node.js. In some cases, these dependencies have a "development" status (`0.x` versions). This means that their behavior can be broken in a minor release of EDOT Node.js.
+:::
+
+The 🔹 symbol denotes settings with a default value or behavior that differs between EDOT Node.js and OTel JS, or that only exists in EDOT Node.js.
+
+| Name | Notes |
+| :--- | :---- |
+| `OTEL_SDK_DISABLED`   | [(Ref)][otel-sdk-envvars] Turn off the SDK. |
+| `OTEL_RESOURCE_ATTRIBUTES`   | [(Ref)][otel-sdk-envvars] Key-value pairs to be used as resource attributes. |
+| `OTEL_SERVICE_NAME`   | [(Ref)][otel-sdk-envvars] Set the `service.name` resource attribute. |
+| `OTEL_LOG_LEVEL`   | [(Ref)][otel-sdk-envvars] Log level used by the SDK internal logger. The default value is `info`. Use `export OTEL_LOG_LEVEL=verbose` for troubleshooting. One of `all`, `verbose`, `debug`, `info`, `warn`, `error`, `none`. |
+| `OTEL_PROPAGATORS` | [(Ref)][otel-sdk-envvars] Propagators to use for distributed tracing. The default value is `tracecontent,baggage`. |
+| `OTEL_TRACES_SAMPLER` | [(Ref)][otel-sdk-envvars] Sampler to use for traces. The default value is `parentbased_always_on`. |
+| `OTEL_TRACES_SAMPLER_ARG` | [(Ref)][otel-sdk-envvars] Meaning depends on `OTEL_TRACES_SAMPLER`. |
+| | |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`   | [(Ref)][otel-exporter-envvars] URL to which to send spans, metrics, or logs. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_ENDPOINT`. |
+| `OTEL_EXPORTER_OTLP_HEADERS`   | [(Ref)][otel-exporter-envvars] Key-value pairs for headers to be used in HTTP or gRPC requests. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_HEADERS`. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | [(Ref)][otel-exporter-envvars] OTLP transport protocol. The default value is `http/protobuf`. One of `http/protobuf`, `grpc`, `http/json`. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_PROTOCOL`. |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | [(Ref)][otel-exporter-envvars] Maximum time, in milliseconds, exporter will wait for a batch export. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_TIMEOUT`. |
+| `OTEL_EXPORTER_OTLP_COMPRESSION` | [(Ref)][otel-exporter-envvars] The default value is `gzip`. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_COMPRESSION`. |
+| `OTEL_EXPORTER_OTLP_INSECURE` | [(Ref)][otel-exporter-envvars] Whether to turn off client transport security for gRPC connections. The default value is `false`. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_INSECURE`. |
+| `OTEL_EXPORTER_OTLP_CLIENT_KEY` | [(Ref)][otel-exporter-envvars] Client private key for mTLS communication. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_CLIENT_KEY`. |
+| `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` | [(Ref)][otel-exporter-envvars] The trusted certificate to use when verifying a server's TLS credentials. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_CLIENT_CERTIFICATE`. |
+| | |
+| `OTEL_NODE_RESOURCE_DETECTORS` | [(EDOT Ref)](#otel_node_resource_detectors-details) Comma-separated list of resource detectors to use. |
+| `OTEL_NODE_ENABLED_INSTRUMENTATIONS` 🔹 | [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details) Comma-separated list of instrumentations to turn on. |
+| `OTEL_NODE_DISABLED_INSTRUMENTATIONS` 🔹 | [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details) Comma-separated list of instrumentations to turn off. |
+| | |
+| `ELASTIC_OTEL_HOST_METRICS_DISABLED` 🔹 | [(EDOT Ref)](#elastic_otel_host_metrics_disabled-details) Turn off collection of metrics done by `@opentelemetry/host-metrics` package. |
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` 🔹 | [(EDOT Ref)](#otel_exporter_otlp_metrics_temporality_preference-details) The metrics exporter's default aggregation `temporality`. The default value is `delta`. The OTel default is `cumulative`. |
+| | |
+| `OTEL_SEMCONV_STABILITY_OPT_IN` 🔹 | [(EDOT Ref)](#otel_semconv_stability_opt_in-details) Control which HTTP semantic conventions are used by `@opentelemetry/instrumentation-http`. The default value is `http`. The OTel default is an empty value. |
+| `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` 🔹 | [(EDOT Ref)](#elastic_otel_context_propagation_only-details) Set to `true` to turn on trace-context propagation in outgoing requests and log correlation. This turns off the sending of spans. |
+| | |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | [(EDOT Ref)](#otel_instrumentation_genai_capture_message_content-details) A boolean to control whether message content should be included in GenAI-related telemetry. |
+| | |
+| `OTEL_BSP_SCHEDULE_DELAY` | [(Ref)][otel-sdk-envvars-bsp] Duration, in milliseconds, between consecutive BatchSpanProcessor exports. The default value is `5000`. |
+| `OTEL_BSP_EXPORT_TIMEOUT` | [(Ref)][otel-sdk-envvars-bsp] Maximum allowed time, in milliseconds, for BatchSpanProcessor to export. The default value is `30000`. |
+| `OTEL_BSP_MAX_QUEUE_SIZE` | [(Ref)][otel-sdk-envvars-bsp] Maximum BatchSpanProcessor queue size. The default value is `2048`. |
+| `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | [(Ref)][otel-sdk-envvars-bsp] Maximum BatchSpanProcessor batch size. The default value is `512`. |
+| | |
+| `OTEL_BLRP_SCHEDULE_DELAY` | [(Ref)][otel-sdk-envvars-blrp] Duration, in milliseconds, between consecutive BatchLogRecordProcessor exports. The default value is `1000`. |
+| `OTEL_BLRP_EXPORT_TIMEOUT` | [(Ref)][otel-sdk-envvars-blrp] Maximum allowed time, in milliseconds, for BatchLogRecordProcessor to export. The default value is `30000`. |
+| `OTEL_BLRP_MAX_QUEUE_SIZE` | [(Ref)][otel-sdk-envvars-blrp] Maximum BatchLogRecordProcessor queue size. The default value is `2048`. |
+| `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` | [(Ref)][otel-sdk-envvars-blrp] Maximum BatchLogRecordProcessor batch size. The default value is `512`. |
+| | |
+| `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` | [(Ref)][otel-sdk-envvars-attr-limits] Maximum allowed attribute value size. The default is no limit. |
+| `OTEL_ATTRIBUTE_COUNT_LIMIT` | [(Ref)][otel-sdk-envvars-attr-limits] Maximum allowed attribute count. The default value is `128`. |
+| `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` | [(Ref)][otel-sdk-envvars-span-limits] Maximum allowed span attribute value size. The default is no limit. |
+| `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` | [(Ref)][otel-sdk-envvars-span-limits] Maximum allowed span attribute count. The default value is `128`. |
+| `OTEL_SPAN_EVENT_COUNT_LIMIT` | [(Ref)][otel-sdk-envvars-span-limits] Maximum allowed span event count. The default value is `128`. |
+| `OTEL_SPAN_LINK_COUNT_LIMIT` | [(Ref)][otel-sdk-envvars-span-limits] Maximum allowed span link count. The default value is `128`. |
+| `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT` | [(Ref)][otel-sdk-envvars-span-limits] Maximum allowed attribute count per span event. The default value is `128`. |
+| `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT` | [(Ref)][otel-sdk-envvars-span-limits] Maximum allowed attribute count per span link. The default value is `128`. |
+| | |
+| `OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT` | [(Ref)][otel-sdk-envvars-logrecord-limits] Maximum allowed log record attribute value size. The default is no limit. |
+| `OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT` | [(Ref)][otel-sdk-envvars-logrecord-limits] Maximum allowed log record attribute count. The default value is `128`. |
+| | |
+| `OTEL_EXPORTER_PROMETHEUS_HOST` | [(Ref)][otel-sdk-envvars-prom] Host used by the Prometheus exporter. The default value is `localhost`. |
+| `OTEL_EXPORTER_PROMETHEUS_PORT` | [(Ref)][otel-sdk-envvars-prom] Port used by the Prometheus exporter. The default value is `9464`. |
+| | |
+| `OTEL_TRACES_EXPORTER` | [(Ref)][otel-sdk-envvars-exp-sel] Trace exporters to use. The default value is `otlp`. Supports: `otlp`, `console`, `zipkin`, `none`. |
+| `OTEL_METRICS_EXPORTER` | [(Ref)][otel-sdk-envvars-exp-sel] Metrics exporters to use. The default value is `otlp`. Supports: `otlp`, `console`, `prometheus`, `none`. |
+| `OTEL_LOGS_EXPORTER` | [(Ref)][otel-sdk-envvars-exp-sel] Logs exporters to use. The default value is `otlp`. Supports: `otlp`, `console`, `none`. |
+| | |
+| `OTEL_METRICS_EXEMPLAR_FILTER` | [(Ref)][otel-sdk-envvars-metrics] Filter for which measurements can become Exemplars. The default value is `trace_based`. One of `always_on`, `always_off`, `trace_based`. |
+| `OTEL_METRIC_EXPORT_INTERVAL` | [(Ref)][otel-sdk-envvars-metrics] Interval, in milliseconds, between consecutive PeriodicExportingMetricReader exports. The default value is `60000`. |
+| `OTEL_METRIC_EXPORT_TIMEOUT` | [(Ref)][otel-sdk-envvars-metrics] Maximum allowed time, in milliseconds, for PeriodicExportingMetricReader to export data. The default value is `30000`. |
+
+The following settings are deprecated:
+
+| Name | Notes |
+| :--- | :---- |
+| `ELASTIC_OTEL_METRICS_DISABLED` 🔹 | [(EDOT Ref)](#deprecated-elastic_otel_metrics_disabled-details) Turn off metrics export and some metrics collection by the SDK. {applies_to}`product: deprecated 1.1.0` |
+
+## Central configuration
+
+```{applies_to}
+serverless: unavailable
+stack: preview 9.1
+product:
+  edot_node: preview 1.2.0
+```
+
+APM Agent Central Configuration lets you configure EDOT Node.js instances remotely, see [Central configuration docs](opentelemetry://reference/central-configuration.md) for more details.
+
+### Turn on central configuration
+
+To activate central configuration, set the `ELASTIC_OTEL_OPAMP_ENDPOINT` environment variable to the OpAMP server endpoint.
+
+```sh
+export ELASTIC_OTEL_OPAMP_ENDPOINT=http://localhost:4320/v1/opamp
+```
+
+To deactivate central configuration, remove the `ELASTIC_OTEL_OPAMP_ENDPOINT` environment variable and restart the instrumented application.
+
+### Central configuration settings
+
+You can modify the following settings for EDOT Node.js through APM Agent Central Configuration:
+
+| Setting | Central configuration name | Type |
+|---------|--------------------------|------|
+| Logging level | `logging_level` | Dynamic |
+| Turn off instrumentations | `deactivate_instrumentations` | Dynamic |
+| Turn off all instrumentations | `deactivate_all_instrumentations` | Dynamic |
+| Send traces | `send_traces` | Dynamic {applies_to}`product: preview 1.3.0` |
+| Send metrics | `send_metrics` | Dynamic {applies_to}`product: preview 1.3.0` |
+| Send logs | `send_logs` | Dynamic {applies_to}`product: preview 1.3.0` |
+
+Dynamic settings can be changed without having to restart the application.
+
+## EDOT configuration details
+
+This section includes additional details on some configuration settings that merit more explanation, or that have behavior that differs in EDOT Node.js when compared to OpenTelemetry JS.
+
+### `OTEL_NODE_RESOURCE_DETECTORS` details [otel_node_resource_detectors-details]
+
+A comma-separated list of named resource detectors to use. EDOT Node.js supports the same set as the [`@opentelemetry/auto-instrumentations-node`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/auto-instrumentations-node/README.md#usage-auto-instrumentation):
+
+- `env`
+- `host`
+- `os`
+- `process`
+- `serviceinstance`
+- `container`
+- `alibaba`
+- `aws`
+- `azure`
+- `gcp`
+- `all` - enable all resource detectors (the default)
+- `none` - disable resource detection
+
+The "cloud" resource detectors (`alibaba`, `aws`, `azure`, `gcp`) typically make HTTP requests to local metadata services to gather [`cloud.*`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/cloud/) and related resource attributes. If it is important to your application to *not* attempt to gather cloud data on startup, use the following or similar:
+
+```bash
+export OTEL_NODE_RESOURCE_DETECTORS=env,host,os,process,serviceinstance,container
+```
+
+In addition, EDOT Node.js always includes the [`telemetry.distro.*` resource attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/telemetry/).
+
+:::{note}
+{{kib}} relies on the `service.instance.id` resource attribute to query and break down data to be shown in [service metrics](docs-content://solutions/observability/apm/metrics-ui.md). If you turn off the `serviceinstance` resource detector, the dashboard won't display any data.
+:::
+
+
+### `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` details [otel_node_disabledenabled_instrumentations-details]
+
+% Note: Linked to by https://ela.st/edot-node-disable-instrs for the central config `deactivate_instrumentations` setting in Kibana.
+
+`OTEL_NODE_DISABLED_INSTRUMENTATIONS` is a comma-separated list of instrumentation names to disable, from the default set.
+`OTEL_NODE_ENABLED_INSTRUMENTATIONS` is a comma-separated list of instrumentation names to enable. Specifying this results in *only* those instrumentations being enabled.
+
+The default set of enabled instrumentations is [the set of included instrumentations](/reference/supported-technologies.md#instrumentations), minus any that are noted as ["disabled by default"](/reference/supported-technologies.md#disabled-instrumentations).
+
+EDOT Node.js handles these settings the same as the [`@opentelemetry/auto-instrumentations-node`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/auto-instrumentations-node/README.md#usage-auto-instrumentation), with one addition. In `@opentelemetry/auto-instrumentations-node`, the name of an instrumentation is the name of the package with the `@opentelemetry/instrumentation-` prefix removed -- `cassandra-driver` refers to the instrumentation provided by `@opentelemetry/instrumentation-cassandra`. EDOT Node.js can include instrumentations that do not have this prefix, for example `@elastic/opentelemetry-instrumentation-openai`. In these cases, the "name" for the instrumentation is the full package name. For example, to enable only instrumentation for openai, http, fastify, and pino one could use:
+
+```bash
+export OTEL_NODE_ENABLED_INSTRUMENTATIONS=http,fastify,pino,@elastic/opentelemetry-instrumentation-openai
+```
+
+### `ELASTIC_OTEL_METRICS_DISABLED` details [deprecated-elastic_otel_metrics_disabled-details]
+
+```{applies_to}
+product:
+ edot_node: deprecated 1.1.0
+```
+
+Setting `ELASTIC_OTEL_METRICS_DISABLED` to `true` turns off metrics export by the SDK and some metrics collection.  This configuration setting is deprecated as of v1.1.0 in favor of using the following settings for finer control:
+
+- To turn off the export of all metrics, set the `OTEL_METRICS_EXPORTER` environment variable to `none`.
+- To turn off collection by the `@opentelemetry/instrumentation-runtime-node` package, set the `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` environment variable to exclude that instrumentation. For example, `OTEL_NODE_DISABLED_INSTRUMENTATIONS=runtime-node`. [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details)
+- To turn off metrics collection by the `@opentelemetry/host-metrics` package, set the `ELASTIC_OTEL_HOST_METRICS_DISABLED` environment variable to `false`.
+
+### `ELASTIC_OTEL_HOST_METRICS_DISABLED` details [elastic_otel_host_metrics_disabled-details]
+
+EDOT Node.js collects and exports [host metrics](/reference/metrics.md#process-and-runtime-metrics) by default, using the `@opentelemetry/host-metrics` package. To turn off host metrics collection, set the `ELASTIC_HOST_OTEL_METRICS_DISABLED` environment variable to `true`.
+
+### `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` details [otel_exporter_otlp_metrics_temporality_preference-details]
+
+{{es}} and {{kib}} work best with metrics provided in delta-temporality.
+Therefore, the EDOT Node.js changes the default value of `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to `delta`.
+You can override this default if needed, note though that some provided {{kib}} dashboards will not work correctly in this case.
+
+OpenTelemetry defaults the temporality preference to `cumulative`. See https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/#additional-environment-variable-configuration
+
+### `OTEL_SEMCONV_STABILITY_OPT_IN` details [otel_semconv_stability_opt_in-details]
+
+The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable is defined by OpenTelemetry as the mechanism for user-controlled migration from experimental to stable semantic conventions. Currently it only applies to HTTP semantic conventions. See [the OpenTelemetry HTTP semconv stability migration doc](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/) for an introduction.
+
+For Node.js usage, the following instrumentations produce telemetry using HTTP semantic conventions:
+
+- `@opentelemetry/instrumentation-http`: Currently transitioning from old to stable HTTP semantic conventions, through the `OTEL_SEMCONV_STABILITY_OPT_IN` setting.
+- `@opentelemetry/instrumentation-undici`: Uses the stable HTTP semantic conventions, because this instrumentation was created after HTTP semconv had stabilized.
+
+EDOT Node.js differs from current OTel JS in that it *defaults `OTEL_SEMCONV_STABILITY_OPT_IN` to `http`*. This means that, by default, all HTTP-related telemetry from EDOT Node.js will use the newer, stable HTTP semantic conventions. (This difference from contrib is expected to be temporary, as `@opentelemetry/instrumentation-http` switches to producing only stable HTTP semantic conventions after its transition period.)
+
+### `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` details [elastic_otel_context_propagation_only-details]
+
+```{applies_to}
+product:
+  edot_node: preview 1.3.0
+```
+
+Set the `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` environment variable to `true` to turn on trace-context propagation in outgoing requests and log correlation. This turns off the sending of spans. Setting `OTEL_TRACES_EXPORTER` to `none` overrides this setting, deactivating trace-context propagation.
+
+Refer to the [migration guide](/reference/migration.md#contextpropagationonly) for details on how this relates to the similar `contextPropagationOnly` setting from the non-OTel Elastic Node.js APM agent.
+
+### `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` details [otel_instrumentation_genai_capture_message_content-details]
+
+Set `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` to `true` to
+enable capture of content data, such as prompt and completion content, in GenAI telemetry. Currently this applies to the [`@elastic/opentelemetry-instrumentation-openai` instrumentation for the OpenAI Node.js client](https://github.com/elastic/elastic-otel-node/tree/main/packages/instrumentation-openai/#configuration) that is included in EDOT Node.js
+
+The `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` boolean environment variable is a convention established by the OpenTelemetry GenAI SIG. It is referenced in <https://opentelemetry.io/blog/2024/otel-generative-ai/>.
+
+### `OTEL_LOGS_EXPORTER` details [otel_logs_exporter-details]
+
+To prevent logs from being exported, set `OTEL_LOGS_EXPORTER` to `none`. However, application logs might still be gathered and exported by the Collector through the `filelog` receiver.
+
+To prevent application logs from being collected and exported by the Collector, refer to [Exclude paths from logs collection](elastic-agent://reference/edot-collector/config/configure-logs-collection.md#exclude-logs-paths).
+
+[otel-sdk-envvars]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration
+[otel-sdk-envvars-bsp]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor
+[otel-sdk-envvars-blrp]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-logrecord-processor
+[otel-sdk-envvars-attr-limits]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#attribute-limits
+[otel-sdk-envvars-span-limits]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits
+[otel-sdk-envvars-logrecord-limits]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#logrecord-limits
+[otel-sdk-envvars-prom]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#prometheus-exporter
+[otel-sdk-envvars-exp-sel]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection
+[otel-sdk-envvars-metrics]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#metrics-sdk-configuration
+[otel-exporter-envvars]: https://opentelemetry.io/docs/specs/otel/protocol/exporter/

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,43 @@
+---
+navigation_title: EDOT Node.js
+description: Introduction to the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js).
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_node: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+  - id: apm-agent
+---
+
+# Elastic Distribution of OpenTelemetry Node.js
+
+The {{edot}} (EDOT) Node.js is a light wrapper around the [OpenTelemetry SDK for Node.js](https://opentelemetry.io/docs/languages/js), configured for the best experience with Elastic Observability.
+
+Use EDOT Node.js to start the OpenTelemetry SDK with your Node.js application, and automatically capture tracing data, performance metrics, and logs. Traces, metrics, and logs can be sent to any OpenTelemetry Protocol (OTLP) Collector you choose.
+
+A goal of this distribution is to avoid introducing proprietary concepts in addition to those defined by the wider OpenTelemetry community. For any additional features introduced, Elastic aims at contributing them back to the OpenTelemetry project.
+
+## Features
+
+In addition to all the features of OpenTelemetry Node.js, with EDOT Node.js you have access to the following:
+
+* A single package that includes several OpenTelemetry packages as dependencies, so you only need to install and update a single package (for most use cases). This is similar to OpenTelemetry's `@opentelemetry/auto-instrumentations-node` package.
+* The [`@elastic/opentelemetry-instrumentation-openai`](https://github.com/elastic/elastic-otel-node/tree/main/packages/instrumentation-openai#readme) instrumentation for monitoring usage of the OpenAI Node.js client library.
+* Improvements and bug fixes contributed by the Elastic team before the changes are available in OpenTelemetry repositories.
+* Optional features that can enhance OpenTelemetry data that is being sent to Elastic.
+* Elastic-specific processors that ensure optimal compatibility when exporting OpenTelemetry signal data to an Elastic backend like an Elastic Observability deployment.
+* Pre-configured collection of tracing and metrics signals, applying some opinionated defaults, such as which sources are collected by default. Additional metrics are collected by default: `process.cpu.*` and `process.memory.*` metrics from the [host-metrics package](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/host-metrics/).
+* Compatibility with APM Agent Central Configuration to modify the settings of the EDOT Node.js agent without having to restart the application.
+
+Use EDOT Node.js with your Node.js application to automatically capture distributed tracing data, performance metrics, and logs. EDOT Node.js automatically instruments [popular modules](/reference/supported-technologies.md#instrumentations) used by your service.
+
+Follow the step-by-step instructions in [Setup](/reference/setup/index.md) to get started.
+
+## Release notes
+
+For the latest release notes, including known issues, deprecations, and breaking changes, refer to [EDOT Node.js release notes](/release-notes/index.md)

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -1,0 +1,46 @@
+---
+navigation_title: Metrics
+description: Metrics produced by the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js).
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_node: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Metrics
+
+In the Elastic Distribution of OpenTelemetry for Node.js (EDOT Node.js) the collection of metrics is turned on by default. Refer to the [settings with `METRIC` in the name](/reference/configuration.md) for all options for configuring metric collection.
+
+## Process and runtime metrics
+
+EDOT Node.js gathers metrics from the Node.js process your application is
+running using the following packages:
+
+- `@opentelemetry/host-metrics` to gather `process.cpu.*` and `process.memory.*` metrics ([ref](https://github.com/open-telemetry/semantic-conventions/blob/80988c54712ee336cb3a6240b8845e9dfa8c9f49/docs/system/process-metrics.md?plain=1#L22)).
+- `@opentelemetry/instrumentation-runtime-node` to gather `nodejs.eventloop.*` ([ref](https://github.com/open-telemetry/semantic-conventions/blob/80988c54712ee336cb3a6240b8845e9dfa8c9f49/model/nodejs/metrics.yaml)) and `v8js.*` ([ref](https://github.com/open-telemetry/semantic-conventions/blob/80988c54712ee336cb3a6240b8845e9dfa8c9f49/model/v8js/metrics.yaml)) metrics.
+
+Process and runtime metrics are useful when you're checking the performance of your instrumented service.
+A subset of them are useful to detect issues when doing an overview of the instrumented service. These are:
+
+- `nodejs.eventloop.delay.p50` and `nodejs.eventloop.delay.p90` are the
+  50th and 90th [percentiles](https://en.wikipedia.org/wiki/Percentile) of
+  the event loop delay. The event loop delay measures the time span between
+  the scheduling of a callback and its execution. The bigger the number,
+  the more sync work you have in your service blocking the event loop.
+- `nodejs.eventloop.utilization` is the utilisation of the event loop reported
+  by [`performance.eventLoopUtilization([utilization1[, utilization2]])`](https://nodejs.org/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2) which gives
+  the percentage of time the event loop is being used (not idle).
+- `process.cpu.utilization` is the percentage of time the CPU is running
+  the service code. Big values in this metric suggest your service is doing
+  compute intensive tasks.
+- `process.memory.usage` is the value of [Resident Set Size](https://nodejs.org/api/process.html#processmemoryusagerss) in bytes. It
+  measures how much memory the process is allocating.
+
+If your service is instrumented by EDOT Node.js, or by custom instrumentation that includes the packages previously mentioned,
+{{kib}} shows them as part of the [service metrics](docs-content://solutions/observability/apm/metrics-ui.md).

--- a/docs/reference/migration.md
+++ b/docs/reference/migration.md
@@ -1,0 +1,238 @@
+---
+navigation_title: Migration
+description: Migrate from the Elastic APM Node.js agent to the Elastic Distribution of OpenTelemetry for Node.js (EDOT Node.js).
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_node: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+  - id: apm-agent
+---
+
+# Migrate to EDOT Node.js from the Elastic APM Node.js agent
+
+Compared to the Elastic APM Node.js agent, the {{edot}} Node.js presents a number of advantages:
+
+- Fully automatic instrumentation with zero code changes. No need to modify application code.
+- EDOT Node.js is built on top of OpenTelemetry SDK and conventions, ensuring compatibility with community tools, vendor-neutral backends, and so on.
+- Modular, extensible architecture based on the OpenTelemetry SDK. You can add custom exporters, processors, and samplers.
+- You can use EDOT Node.js in environments where both tracing and metrics are collected using OpenTelemetry.
+
+
+## Migration steps
+
+Follow these steps to migrate from the legacy Elastic APM PHP agent (`elastic-apm-node`) to the {{edot}} PHP (`@elastic/opentelemetry-node`).
+
+::::::{stepper}
+
+::::{step} Replace the Node.js package
+
+Remove the Elastic APM Node.js Agent package and install EDOT Node.js:
+
+```sh
+npm uninstall elastic-apm-node
+npm install --save @elastic/opentelemetry-node
+```
+
+::::
+
+::::{step} Remove APM Node.js start method
+
+For services starting the APM Node.js Agent by using `require()` with the [require and start](apm-agent-nodejs://reference/starting-agent.md#start-option-require-and-start) or [require start module](apm-agent-nodejs://reference/starting-agent.md#start-option-require-start-module) methods, the `require('elastic-apm-node')`, remove the code.
+
+For services starting with the [`--require` Node.js CLI option](apm-agent-nodejs://reference/starting-agent.md#start-option-node-require-opt), remove the option. If the `--require` option is defined in `NODE_OPTIONS` environment variable, remove it there.
+
+::::
+
+::::{step} (Optional) Migrate manual instrumentation API
+If you're using the [Elastic APM Node.js Agent API](apm-agent-nodejs://reference/api.md) to create manual transactions and spans you should refactor the code to use `@opentelemetry/api` methods. OpenTelemetry documentation has several examples of how to [create spans](https://opentelemetry.io/docs/languages/js/instrumentation/#create-spans) manually.
+::::
+
+::::{step} Replace configuration options
+Refer to the [Configuration mapping](#configuration-mapping). Refer to [Configuration](/reference/configuration.md) for details on EDOT Node.js configuration.
+::::
+
+::::{step} Add EDOT Node.js start method
+
+Use the [Node.js `--import` option](https://nodejs.org/api/cli.html#--importmodule) to start EDOT Node.js with your service.
+
+Set it on the command-line using `node --import @elastic/opentelemetry-node service.js` or in the [`NODE_OPTIONS` environment variable](https://nodejs.org/api/cli.html#node_optionsoptions): `NODE_OPTIONS="--import @elastic/opentelemetry-node" node service.js`.
+::::
+
+::::::
+
+## Configuration mapping
+
+This list contains Elastic APM Node.js agent configuration options that can be migrated to EDOT Node.js SDK configuration because they have an equivalent in OpenTelemetry.
+
+### `active`
+
+The Elastic APM Node.js agent [`active`](apm-agent-nodejs://reference/configuration.md#active) option corresponds to the OpenTelemetry [OTEL_SDK_DISABLED](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) option but it has the opposite meaning. 
+
+Set the `OTEL_SDK_DISABLED` to `true` if you want to deactivate the agent. For example: `OTEL_SDK_DISABLED=true`.
+
+### `apiKey`
+
+The Elastic APM Node.js agent [`apiKey`](apm-agent-nodejs://reference/configuration.md#api-key) option corresponds to setting the `Authorization` header in the OpenTelemetry [OTEL_EXPORTER_OTLP_HEADERS](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_headers) option.
+
+For example:`OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey an_api_key"`.
+
+### `apmClientHeaders`
+
+The Elastic APM Node.js agent [`apmClientHeaders`](apm-agent-nodejs://reference/configuration.md#apm-client-headers) option corresponds to the OpenTelemetry [`OTEL_EXPORTER_OTLP_HEADERS`](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specifying-headers-via-environment-variables) option.
+
+For example: `OTEL_EXPORTER_OTLP_HEADERS=foo=bar,baz=quux`.
+
+### `cloudProvider`
+
+The Elastic APM Node.js agent [`cloudProvider`](apm-agent-nodejs://reference/configuration.md#cloud-provider) option does not corresponds directly to an OpenTelemetry option but you can get similar behavior by properly setting [`OTEL_NODE_RESOURCE_DETECTORS`](https://opentelemetry.io/docs/zero-code/js/configuration/#sdk-resource-detector-configuration) option. If you set this option make sure you add along with the cloud detector the non-cloud detectors that apply to your service. For a full list of detectors check [OTEL_NODE_RESOURCE_DETECTORS details](/reference/configuration.md#otel_node_resource_detectors-details). Not setting this option is the equivalent of `auto`.
+
+For example: `OTEL_NODE_RESOURCE_DETECTORS=os,env,host,serviceinstance,process,aws` will make the agent query for AWS metadata only and use other non-cloud detectors to enrich that metadata.
+
+### `disableInstrumentations`
+
+The Elastic APM Node.js agent [`disableInstrumentations`](apm-agent-nodejs://reference/configuration.md#disable-instrumentations) option corresponds to the EDOT Node.js [`OTEL_NODE_DISABLED_INSTRUMENTATIONS`](/reference/configuration.md#otel_node_disabledenabled_instrumentations-details) option.
+
+For example: `OTEL_NODE_DISABLED_INSTRUMENTATIONS=express,mysql`.
+
+### `environment`
+
+The Elastic APM Node.js agent [`environment`](apm-agent-nodejs://reference/configuration.md#environment) option corresponds to setting the `deployment.environment` key in [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes).
+
+For example: `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=testing`.
+
+### `globalLabels`
+
+The Elastic APM Node.js agent [`globalLabels`](apm-agent-nodejs://reference/configuration.md#global-labels) option corresponds to adding `key=value` comma separated pairs in [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes).
+
+For example: `OTEL_RESOURCE_ATTRIBUTES=alice=first,bob=second`. Such labels will result in labels.key=value attributes on the server. For example, `labels.alice=first`.
+
+### `logLevel`
+
+The Elastic APM Node.js agent [`logLevel`](apm-agent-nodejs://reference/configuration.md#log-level) option corresponds to the OpenTelemetry [`OTEL_LOG_LEVEL`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) option. 
+
+The following table shows the equivalent values of log levels between `elastic-apm-node` and EDOT Node.js.
+
+| ELASTIC_APM_LOG_LEVEL | OTEL_LOG_LEVEL |
+| --------------------- | -------------- |
+| `off`                 | `none`         |
+| `error`               | `error`        |
+| `warn`                | `warn`         |
+| `info`                | `info`         |
+| `debug`               | `debug`        |
+| `trace`               | `verbose`      |
+| `trace`               | `all`          |
+
+### `contextPropagationOnly`
+
+The equivalent of the Elastic APM Node.js agent [`contextPropagationOnly`](apm-agent-nodejs://reference/configuration.md#context-propagation-only) option can be accomplished with the following EDOT Node.js settings:
+
+- [`ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY=true`](/reference/configuration.md#elastic_otel_context_propagation_only-details) to configure trace-context propagation. This turns off sending spans and the overhead from doing so. Note that using `OTEL_TRACES_EXPORTER=none` turns off context-propagation. The `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` EDOT Node.js setting only impacts tracing, as opposed to the APM agent `contextPropagationOnly` which impacts both tracing and metric collection.
+- To turn off metrics sending and collection overhead, use the following settings:
+    - [`OTEL_METRICS_EXPORTER=none`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection) to turn off the sending of any metrics.
+    - [`ELASTIC_OTEL_HOST_METRICS_DISABLED=true`](/reference/configuration.md#elastic_otel_host_metrics_disabled-details) to remove the overhead from metrics collection by the `@opentelemetry/host-metrics` package.
+    - [`OTEL_NODE_DISABLED_INSTRUMENTATIONS=runtime-node`](/reference/configuration.md#otel_node_disabledenabled_instrumentations-details) to remove metrics collection overhead from the `@opentelemetry/instrumentation-runtime-node` instrumentation
+
+For example:
+
+```
+ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY=true
+OTEL_METRICS_EXPORTER=none
+ELASTIC_OTEL_HOST_METRICS_DISABLED=true
+OTEL_NODE_DISABLED_INSTRUMENTATIONS=runtime-node
+```
+
+### `maxQueueSize`
+
+The Elastic APM Node.js agent [`maxQueueSize`](apm-agent-nodejs://reference/configuration.md#max-queue-size) option corresponds to a couple of OpenTelemetry options:
+
+- [`OTEL_BSP_MAX_QUEUE_SIZE`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor) option to set the queue size for spans.
+- [`OTEL_BLRP_MAX_QUEUE_SIZE`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor) option to set the queue size for logs.
+
+For example: `OTEL_BSP_MAX_QUEUE_SIZE=2048 OTEL_BLRP_MAX_QUEUE_SIZE=4096`.
+
+### `metricsInterval`
+
+The Elastic APM Node.js agent [`metricsInterval`](apm-agent-nodejs://reference/configuration.md#metrics-interval) option corresponds to the OpenTelemetry [`OTEL_METRIC_EXPORT_INTERVAL`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader) option.
+
+For example: `OTEL_METRIC_EXPORT_INTERVAL=30000`.
+
+### `secretToken`
+
+The Elastic APM Node.js agent [`secretToken`](apm-agent-nodejs://reference/configuration.md#secret-token) option corresponds to setting the `Authorization` header in the OpenTelemetry [OTEL_EXPORTER_OTLP_HEADERS](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_headers) option.
+
+For example: `OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer an_apm_secret_token"`.
+
+:::{note}
+Secret token usage is discouraged. Use API keys for authentication.
+:::
+
+### `serverTimeout`
+
+The Elastic APM Node.js agent [`serverTimeout`](apm-agent-nodejs://reference/configuration.md#server-timeout) option corresponds to a OpenTelemetry options per signal:
+
+- [`OTEL_BLRP_EXPORT_TIMEOUT`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-logrecord-processor) option for logs.
+- [`OTEL_BSP_EXPORT_TIMEOUT`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor) option for spans.
+- [`OTEL_METRIC_EXPORT_TIMEOUT`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor) option for metrics.
+
+For example: `OTEL_BSP_EXPORT_TIMEOUT=50000 OTEL_BLRP_EXPORT_TIMEOUT=50000 OTEL_METRIC_EXPORT_TIMEOUT=50000`.
+
+### `serverUrl`
+
+The Elastic APM Node.js agent [`serverUrl`](apm-agent-nodejs://reference/configuration.md#server-url) option corresponds to the OpenTelemetry [`OTEL_EXPORTER_OTLP_ENDPOINT`](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_endpoint) option.
+
+- If using {{serverless-full}}, set `OTEL_EXPORTER_OTLP_ENDPOINT` to the [{{motlp}}](opentelemetry://reference/motlp.md) URL for your Serverless project. For example, `OTEL_EXPORTER_OTLP_ENDPOINT=https://my-prj-a1b2c3.ingest.eu-west-1.aws.elastic.cloud`. Refer to the [Quickstart for {{serverless-full}}](docs-content://solutions/observability/get-started/opentelemetry/quickstart/serverless/index.md).
+
+- If using {{ech}} or Self-managed, set `OTEL_EXPORTER_OTLP_ENDPOINT` to the endpoint URL of your EDOT Collector. Refer to the [Quickstart for {{ech}}](docs-content://solutions/observability/get-started/opentelemetry/quickstart/ech/hosts_vms.md) or the [Quickstart for Self-managed](docs-content://solutions/observability/get-started/opentelemetry/quickstart/self-managed/hosts_vms.md).
+
+### `serviceName`
+
+The Elastic APM Node.js agent [`serviceName`](apm-agent-nodejs://reference/configuration.md#service-name) option corresponds to the OpenTelemetry [OTEL_SERVICE_NAME](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_service_name) option.
+
+You can also set the service name using [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes). For example: `OTEL_RESOURCE_ATTRIBUTES=service.name=myservice`. A value in `OTEL_SERVICE_NAME` takes precedence over a `service.name` value in `OTEL_RESOURCE_ATTRIBUTES`.
+
+### `serviceVersion`
+
+The Elastic APM Node.js agent [`serviceVersion`](apm-agent-nodejs://reference/configuration.md#service-version) option corresponds to setting the `service.version` key in [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes).
+
+For example: `OTEL_RESOURCE_ATTRIBUTES=service.version=1.2.3`.
+
+### `transactionSampleRate`
+
+The Elastic APM Node.js agent [`transactionSampleRate`](apm-agent-nodejs://reference/configuration.md#transaction-sample-rate) corresponds to the OpenTelemetry `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` options. 
+
+For example, for the equivalent of `transactionSampleRate: '0.25'` use `OTEL_TRACES_SAMPLER=parentbased_traceidratio OTEL_TRACES_SAMPLER_ARG=0.25`.
+
+## Limitations
+
+The following limitations apply to EDOT Node.js.
+
+### Supported Node.js versions
+
+EDOT Node.js and OpenTelemetry SDK support Node.js versions in the range `^18.19.0 || >=20.6.0`. Elastic APM Node.js works with Node.js versions `>=14.17.0`, though with limited support for Node.js 14 and 16 given that those major versions of Node.js are out of long-term support.
+
+### Missing instrumentations
+
+EDOT Node.js doesn't currently support instrumentation for AWS Lambda and Azure Functions. However, there are contrib and third-party options based on OpenTelemetry:
+
+- For AWS Lambda use [OpenTelemetry Lambda layers](https://github.com/open-telemetry/opentelemetry-lambda).
+- For Azure Functions you can [configure OpenTelemetry](https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto?tabs=app-insights&pivots=programming-language-javascript).
+
+### Central configuration
+
+You can manage EDOT Node.js configurations through the [central configuration feature](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) in the Applications UI.
+
+Refer to [Central configuration](opentelemetry://reference/central-configuration.md) for more information.
+
+### Span compression
+
+EDOT Node.js does not implement [span compression](docs-content://solutions/observability/apm/spans.md#apm-spans-span-compression).
+
+## Troubleshooting
+
+If you're encountering issues during migration, refer to the [EDOT Node.js troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/nodejs/index.md).

--- a/docs/reference/setup/index.md
+++ b/docs/reference/setup/index.md
@@ -1,0 +1,116 @@
+---
+navigation_title: Setup
+description: How to set up the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js).
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_node: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Set up EDOT Node.js
+
+To monitor your service with the {{edot}} (EDOT) Node.js you need to install it, configure it, and properly start it with your application.
+
+For example, the following commands perform the minimal setup steps:
+
+```bash
+# Install it
+npm install --save @elastic/opentelemetry-node
+
+# Configure it
+export OTEL_EXPORTER_OTLP_ENDPOINT="...your-ELASTIC_OTLP_ENDPOINT..."
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey ...your-ELASTIC_API_KEY..."
+export OTEL_SERVICE_NAME="my-app"
+
+# Start it with your application
+node --import @elastic/opentelemetry-node my-app.js
+```
+:::{warning}
+Avoid using the Node.js SDK alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+:::
+
+If you are deploying in Kubernetes, see the [Kubernetes setup guide](/reference/setup/k8s.md).
+
+## Prerequisites
+
+Before getting started, you need somewhere to send the gathered OpenTelemetry data, so it can be viewed and analyzed. This doc assumes you're using an Elastic Observability deployment. You can use an existing one or set up a new one.
+
+Follow the EDOT [Quickstart guide](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md) to get a deployment and gather the `ELASTIC_OTLP_ENDPOINT` and `ELASTIC_API_KEY` pieces of data that you need to configure the EDOT Node.js SDK.
+
+## Installation
+
+EDOT Node.js is published to npm as the [`@elastic/opentelemetry-node` package](https://www.npmjs.com/package/@elastic/opentelemetry-node). Install it with your chosen package manager:
+
+```bash
+npm install @elastic/opentelemetry-node  
+yarn add @elastic/opentelemetry-node    
+pnpm add @elastic/opentelemetry-node
+```
+
+## Configuration
+
+EDOT Node.js is configured with environment variables beginning with `OTEL_` or `ELASTIC_OTEL_`. Any `OTEL_*` environment variables behave the same as with the OpenTelemetry SDK. 
+
+For example, all the OpenTelemetry [General SDK Configuration env vars](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) are supported. If EDOT Node.js provides a configuration setting specific to the Elastic distribution, it begins with `ELASTIC_OTEL_`.
+
+### Basic configuration
+
+To configure EDOT Node.js, as a typical minimum you need:
+
+* `OTEL_EXPORTER_OTLP_ENDPOINT`: The full URL of an OpenTelemetry Collector where data is sent. When using Elastic Observability, this is the ingest endpoint of an {{serverless-full}} project or the URL of a deployed [EDOT Collector](elastic-agent://reference/edot-collector/index.md). Set this to the `ELASTIC_OTLP_ENDPOINT` value as described in the [EDOT Quickstart pages](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md).
+* `OTEL_EXPORTER_OTLP_HEADERS`: A comma-separated list of HTTP headers used for exporting data, typically used to set the `Authorization` header with auth information. Get an `ELASTIC_API_KEY` as described in the [EDOT Quickstart pages](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md) and set this to `"Authorization=ApiKey ELASTIC_API_KEY"`.
+* `OTEL_SERVICE_NAME`: The name of your service, used to distinguish telemetry data from other services in your system. If not set, it defaults to `unknown_service:node`.
+
+:::{note}
+In some environments, for example in some Kubernetes setups, a local OpenTelemetry Collector is deployed with an endpoint of `http://localhost:4318`. This is the default exporter endpoint used by EDOT Node.js. In this case the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable does not need to be set.
+:::
+
+### Additional configuration
+
+Additional other common configuration settings that might be useful include:
+
+* `OTEL_RESOURCE_ATTRIBUTES=service.version=<app-version>,deployment.environment=production`: This environment variable can be used to set additional [Resource attributes](https://opentelemetry.io/docs/languages/js/resources/). Setting `service.version` can be useful for correlating issues to different versions of your service. Setting `deployment.environment` can be useful for separating telemetry for development, test, qa, or production deployments of your services.
+* `OTEL_NODE_DISABLED_INSTRUMENTATIONS=net,dns,...`: A comma-separated list of instrumentation names to disable. This can be useful if a particular instrumentation is unwanted for some reason.
+* `OTEL_LOG_LEVEL=verbose`: This can be used to get more internal logging data from EDOT Node.js when investigating issues with telemetry.
+* `OTEL_SDK_DISABLED=true`: This can be used to fully disable EDOT Node.js, perhaps when troubleshooting.
+
+For more information on all the available configuration options, refer to [Configuration](/reference/configuration.md).
+
+## Start EDOT Node.js
+
+For EDOT Node.js to automatically instrument modules used by your Node.js service, start it before you `require` or `import` your service code's dependencies. For example, before `express` or `http` are loaded.
+
+The recommended way to start EDOT Node.js is by using the `--import` Node.js [CLI option](https://nodejs.org/api/cli.html#--importmodule). This loads and starts the SDK in Node.js' "preload" phase, which ensures that it is started before any application modules.
+
+```sh
+node --import @elastic/opentelemetry-node my-app.js
+```
+
+You can also specify the `--import` option in the `NODE_OPTIONS` environment variable:
+
+```bash
+export NODE_OPTIONS="--import @elastic/opentelemetry-node"
+node my-app.js
+```
+
+EDOT Node.js automatically instruments popular modules, listed in [Supported technologies](/reference/supported-technologies.md), used by your service, and send traces, metrics, and logs telemetry data (using OTLP) to your configured observability backend.
+
+## Confirm instrumentation is working
+
+To confirm that EDOT Node.js has be setup successfully:
+
+1. Call your running service to ensure it has had some activity that EDOT Node.js can trace.
+2. Go to **Applications** → **Service Inventory** in your Elastic Observability deployment.
+3. Find the name of your service. It can take a minute or two after starting your service with EDOT Node.js for the service to show up in this list.
+
+If you do not see your service, work through [the Troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/nodejs/index.md).
+
+## Troubleshooting
+
+For help with common setup issues, refer to the [EDOT Node.js troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/nodejs/index.md).

--- a/docs/reference/setup/k8s.md
+++ b/docs/reference/setup/k8s.md
@@ -1,0 +1,171 @@
+---
+navigation_title: Kubernetes
+description: How to instrument Node.js applications on Kubernetes using the Elastic Distribution of OpenTelemetry (EDOT).
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_node: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Instrumenting Node.js applications with EDOT SDKs on Kubernetes
+
+Learn how to instrument Node.js applications on Kubernetes, using the OpenTelemetry Operator, the {{edot}} (EDOT) Collectors, and the EDOT Node.js SDK.
+
+- For general knowledge about the EDOT Node.js SDK, refer to the [EDOT Node.js Intro page](/reference/index.md) and [Configuration](/reference/configuration.md).
+- For Node.js auto-instrumentation specifics, refer to [OpenTelemetry Operator Node.js auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#nodejs).
+- For general information about instrumenting applications on Kubernetes, refer to [instrumenting applications on Kubernetes](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/instrumenting-applications.md).
+
+## Instrument a Node.js app on Kubernetes
+
+::::::{stepper}
+
+::::{step} Ensure the OpenTelemetry Operator and Instrumentation object exist
+Ensure you have successfully [installed the OpenTelemetry Operator](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/deployment.md), and confirm that the following `Instrumentation` object exists in the system:
+
+```bash
+$ kubectl get instrumentation -n opentelemetry-operator-system
+NAME                      AGE    ENDPOINT
+elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
+```
+
+:::{note}
+If your `Instrumentation` object has a different name or is created in a different namespace, you will have to adapt the annotation value in the next step.
+:::
+::::
+
+::::{step} Enable auto-instrumentation for your Node.js application
+Enable auto-instrumentation of your Node.js application using one of the following methods:
+
+- Edit your application workload definition and include the annotation under `spec.template.metadata.annotations`:
+
+  ```yaml
+  kind: Deployment
+  metadata:
+    name: nodejs-app
+    namespace: nodejs-ns
+  spec:
+  ...
+    template:
+      metadata:
+  ...
+        annotations:
+          instrumentation.opentelemetry.io/inject-nodejs: opentelemetry-operator-system/elastic-instrumentation
+  ...
+  ```
+
+- Alternatively, add the annotation at namespace level to apply auto-instrumentation in all Pods of the namespace:
+
+  ```bash
+  kubectl annotate namespace nodejs-ns instrumentation.opentelemetry.io/inject-nodejs=opentelemetry-operator-system/elastic-instrumentation
+  ```
+::::
+
+::::{step} Restart your application
+Once the annotation has been set, restart the application to create new Pods and inject the instrumentation libraries:
+
+  ```bash
+  kubectl rollout restart deployment nodejs-app -n nodejs-ns
+  ```
+::::
+
+::::{step} Verify auto-instrumentation resources in the Pods
+Verify the [auto-instrumentation resources](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/instrumenting-applications.md#how-auto-instrumentation-works) are injected in the Pods:
+
+Run a `kubectl describe` of one of your application Pods and check:
+
+- There should be an init container named `opentelemetry-auto-instrumentation-nodejs` in the Pod. For example:
+
+  ```bash
+  $ kubectl describe pod nodejs-app-8d84c47b8-8h5z2 -n nodejs-ns
+  Name:             nodejs-app-8d84c47b8-8h5z2
+  Namespace:        nodejs-ns
+  ...
+  ...
+  Init Containers:
+    opentelemetry-auto-instrumentation-nodejs:
+      Container ID:  containerd://cbf67d7ca1bd62c25614b905a11e81405bed6fd215f2df21f84b90fd0279230b
+      Image:         docker.elastic.co/observability/elastic-otel-node:0.5.0
+      Command:
+        cp
+        -r
+        /autoinstrumentation/.
+        /otel-auto-instrumentation-nodejs
+      State:          Terminated
+        Reason:       Completed
+        Exit Code:    0
+        Started:      Wed, 13 Nov 2024 15:47:02 +0100
+        Finished:     Wed, 13 Nov 2024 15:47:03 +0100
+      Ready:          True
+      Restart Count:  0
+      Environment:    <none>
+      Mounts:
+        /otel-auto-instrumentation-nodejs from opentelemetry-auto-instrumentation-nodejs (rw)
+        /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-swhn5 (ro)
+  ```
+
+- The main container of the deployment loads the SDK through the `NODE_OPTIONS` environment variable:
+
+  ```bash
+  ...
+  Containers:
+    nodejs-app:
+      Environment:
+  ...
+        NODE_OPTIONS:                           --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js
+        OTEL_SERVICE_NAME:                     nodejs-app
+        OTEL_EXPORTER_OTLP_ENDPOINT:           http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
+  ...
+  ```
+
+  Ensure the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` points to a valid endpoint and there's network communication between the Pod and the endpoint.
+
+- The Pod has an `EmptyDir` volume named `opentelemetry-auto-instrumentation-nodejs` mounted in both the main and the init containers in path `/otel-auto-instrumentation-nodejs`.
+
+  ```bash
+  Init Containers:
+    opentelemetry-auto-instrumentation-nodejs:
+  ...
+      Mounts:
+        /otel-auto-instrumentation-nodejs from opentelemetry-auto-instrumentation-nodejs (rw)
+  Containers:
+    nodejs-app:
+  ...
+      Mounts:
+        /otel-auto-instrumentation-nodejs from opentelemetry-auto-instrumentation-nodejs (rw)
+  ...
+  Volumes:
+  ...
+    opentelemetry-auto-instrumentation-nodejs:
+      Type:        EmptyDir (a temporary directory that shares a pod's lifetime)
+  ```
+::::
+
+::::{step} Confirm data is flowing to {{kib}}
+Confirm data is flowing to **{{kib}}**:
+
+- Open **Observability** → **Applications** → **Service inventory**, and determine if:
+    - The application appears in the list of services (`nodejs-app` in the example).
+    - The application shows transactions and metrics.
+
+    :::{note}
+    You may need to generate traffic to your application to see spans and metrics.
+    :::
+
+- For application container logs, open **{{kib}} Discover** and filter for your Pods' logs. In the provided example, you could filter for them with either of the following:
+    - `k8s.deployment.name: "nodejs-app"` (adapt the query filter to your use case).
+    - `k8s.pod.name: nodejs-app*` (adapt the query filter to your use case).
+
+Note that the container logs are not provided by the instrumentation library, but by the DaemonSet collector deployed as part of the [operator installation](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/deployment.md).
+::::
+
+::::::
+
+## Troubleshooting
+
+Refer to [troubleshoot auto-instrumentation](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/instrumenting-applications.md#troubleshooting-auto-instrumentation) for further analysis.

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -1,0 +1,142 @@
+---
+navigation_title: Supported Technologies
+description: Supported technologies for the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js).
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_node: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-sdk
+---
+
+# Technologies supported by the EDOT Node.js SDK
+
+The EDOT Node.js agent is a [distribution](https://opentelemetry.io/docs/concepts/distributions/) of OpenTelemetry Node.js. It inherits all the [supported](opentelemetry://reference/compatibility/nomenclature.md) technologies of the OpenTelemetry Node.js.
+
+## EDOT Collector and Elastic Stack versions
+
+The {{edot}} Node.js (EDOT Node.js) sends data through the OpenTelemetry protocol (OTLP). While OTLP ingest works with later 8.16+ versions of the EDOT Collector, for full support use either [EDOT Collector](elastic-agent://reference/edot-collector/index.md) versions 9.x or [{{serverless-full}}](docs-content://deploy-manage/deploy/elastic-cloud/serverless.md) for OTLP ingest.
+
+:::{note}
+Ingesting data from EDOT SDKs through EDOT Collector 9.x into Elastic Stack versions 8.18+ is supported.
+:::
+
+Refer to [EDOT SDKs compatibility](opentelemetry://reference/compatibility/sdks.md) for support details.
+
+## Node.js versions
+
+EDOT Node.js supports Node.js 18.19.0, 20.6.0, or later. This follows from the [OpenTelemetry JS supported runtimes](https://github.com/open-telemetry/opentelemetry-js#supported-runtimes).
+
+## TypeScript versions
+
+Usage of `@elastic/opentelemetry-node` in TypeScript code requires:
+
+- TypeScript 5.0.4 or later
+- Using `"module": "node16"` or "nodenext" in "tsconfig.json" to get support for handling the "exports" entry in package.json. This is so the `@elastic/opentelemetry-node/sdk` entry-point can be used.
+
+## Instrumentations [instrumentations]
+
+The following instrumentations are included in EDOT Node.js. All are turned on by default, except those noted _disabled by default_.
+
+The 🔹 symbol marks instrumentations that differ between EDOT Node.js and OTel JS, or that only exist in EDOT Node.js.
+
+| Name | Packages instrumented | Notes |
+|---|---|---|
+| `@elastic/opentelemetry-instrumentation-openai` 🔹 | `openai` version range `>=4.19.0 <5` | [README](https://github.com/elastic/elastic-otel-node/tree/main/packages/instrumentation-openai#readme) |
+| `@opentelemetry/instrumentation-amqplib` | `amqplib` version range `>=0.5.5 <1` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-amqplib#readme) |
+| `@opentelemetry/instrumentation-aws-sdk` | `aws-sdk` v2 and `@aws-sdk/client-*` v3 | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-aws-sdk#readme) |
+| `@opentelemetry/instrumentation-bunyan` | `bunyan` version range `^1.0.0` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-bunyan#readme) |
+| `@opentelemetry/instrumentation-cassandra-driver` | `cassandra-driver` version range `>=4.4.0 <5` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-cassandra-driver#readme) |
+| `@opentelemetry/instrumentation-connect` | `connect` version range `^3.0.0` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-connect#readme) |
+| `@opentelemetry/instrumentation-cucumber` | `@cucumber/cucumber` version range `>=8.0.0 <11` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-cucumber#readme) |
+| `@opentelemetry/instrumentation-dataloader` | `dataloader` version range `>=2.0.0 <3` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-dataloader#readme) |
+| `@opentelemetry/instrumentation-dns` | `dns` module for supported Node.js versions | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-dns#readme) |
+| `@opentelemetry/instrumentation-express` | `express` version range `^4.0.0` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-express#readme) |
+| `@opentelemetry/instrumentation-fastify` | `fastify` version range `>=3 <5` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-fastify#readme), [disabled by default](#disabled-instrumentations) |
+| `@opentelemetry/instrumentation-fs` | `fs` module for supported Node.js versions | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-fs#readme), [disabled by default](#disabled-instrumentations) |
+| `@opentelemetry/instrumentation-generic-pool` | `generic-pool` version range `2 - 2.3, ^2.4, >=3` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-generic-pool#readme) |
+| `@opentelemetry/instrumentation-graphql` | `graphql` version range `>=14.0.0 <17` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-graphql#readme) |
+| `@opentelemetry/instrumentation-grpc` | `@grpc/grpc-js` version range `^1.0.0` | [README](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc#readme) |
+| `@opentelemetry/instrumentation-hapi` | `@hapi/hapi >=17.0.0 <21` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-hapi#readme) |
+| `@opentelemetry/instrumentation-http` | `http` module for supported Node.js versions | [README](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http#readme) |
+| `@opentelemetry/instrumentation-ioredis` | `ioredis` version range `>=2 <6` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-ioredis#readme) |
+| `@opentelemetry/instrumentation-kafkajs` | `kafkajs` version range `>=0.1.0 <3` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-kafkajs#readme) |
+| `@opentelemetry/instrumentation-knex` | `knex` version range `>=0.10.0` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-knex#readme) |
+| `@opentelemetry/instrumentation-koa` | `koa` version range `^2.0.0` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-koa#readme) |
+| `@opentelemetry/instrumentation-lru-memoizer` | `lru-memoizer` version range `>=1.3 <3` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-lru-memoizer#readme) |
+| `@opentelemetry/instrumentation-memcached` | `memcached` version range `>=2.2` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-memcached#readme) |
+| `@opentelemetry/instrumentation-mongodb` | `mongodb` version range `>=3.3 <7` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-mongodb#readme) |
+| `@opentelemetry/instrumentation-mongoose` | `mongoose` version range `>=5.9.7 <9` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-mongoose#readme) |
+| `@opentelemetry/instrumentation-mysql` | `mysql` version range `>=2.0.0 <3` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/instrumentation-mysql#readme) |
+| `@opentelemetry/instrumentation-mysql2` | `mysql2` version range `>=1.4.2 <4` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/instrumentation-mysql2#readme) |
+| `@opentelemetry/instrumentation-nestjs-core` | `@nestjs/core` version range `>=4.0.0` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-nestjs-core#readme) |
+| `@opentelemetry/instrumentation-net` | `net` module for supported Node.js versions | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-net#readme) |
+| `@opentelemetry/instrumentation-oracledb` {applies_to}`edot_node: ga 1.3.0` | `oracledb` version range `>=6.7.0 <7` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-oracledb#readme) |
+| `@opentelemetry/instrumentation-pg` | `pg` version range `>=8 <9` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-pg#readme) |
+| `@opentelemetry/instrumentation-pino` | `pino` version range `>=5.14.0 <10` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-pino#readme) |
+| `@opentelemetry/instrumentation-redis` | `redis` version range `>=2.6.0 <5` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-redis#readme) |
+| `@opentelemetry/instrumentation-restify` | `restify` version range `>=4.0.0 <12` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-restify#readme) |
+| `@opentelemetry/instrumentation-router` | `router` version range `1` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-router#readme) |
+| `@opentelemetry/instrumentation-runtime-node` | N/A (provides Node.js runtime metrics) | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-runtime-node#readme) |
+| `@opentelemetry/instrumentation-socket.io` | `socket.io` version range `2, >=3 <5` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-socket.io#readme) |
+| `@opentelemetry/instrumentation-tedious` | `tedious` version range `>=1.11.0 <=15` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-tedious#readme) |
+| `@opentelemetry/instrumentation-undici` | `undici` version range `>=5.12.0` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-undici#readme) |
+| `@opentelemetry/instrumentation-winston` | `winston` version range `>1 <4` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-winston#readme) |
+
+### LLM instrumentations
+
+EDOT Node.js can instrument the following Large Language Model (LLM) libraries with instrumentations implementing the [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
+
+| SDK    | Instrumentation | Traces | Metrics | Logs | Notes |
+|--------|-----------------|--------|---------|------|-------|
+| OpenAI | [@elastic/opentelemetry-instrumentation-openai](https://github.com/elastic/elastic-otel-node/tree/main/packages/instrumentation-openai#readme) | ✅         | ✅          | ✅       | (1)       |
+
+1. Support for [chat](https://platform.openai.com/docs/api-reference/chat) and [embeddings](https://platform.openai.com/docs/api-reference/embeddings) API endpoints.
+
+### Deactivated instrumentations [disabled-instrumentations]
+
+The following instrumentations are included in EDOT Node.js, but deactivated by default:
+
+- `@opentelemetry/instrumentation-fs` (Deactivated upstream in [open-telemetry/opentelemetry-js-contrib#2467](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2467).)
+- `@opentelemetry/instrumentation-fastify` (Deprecated upstream and slated for removal. Refer to [open-telemetry/opentelemetry-js-contrib#2652](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2652))
+
+To turn on these instrumentations, use the [`OTEL_NODE_ENABLED_INSTRUMENTATIONS` environment variable](/reference/configuration.md#otel_node_disabledenabled_instrumentations-details). Make sure you list all the instrumentations you need for your service since only the ones in that list will be activated. For example:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://my-deployment-abc123.ingest.us-west-2.aws.elastic.cloud"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey Zm9vO...mJhcg=="
+export OTEL_SERVICE_NAME=my-app
+export OTEL_NODE_ENABLED_INSTRUMENTATIONS="fs,http,fastify" # only the ones in the list would be enabled
+node --import @elastic/opentelemetry-node my-service.js
+```
+
+EDOT Node.js uses the [`@opentelemetry/auto-instrumentations-node` package set of instrumentations](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/metapackages/auto-instrumentations-node/README.md#supported-instrumentations) as a guide for instrumentations to include, exclude, or turn off by default. This is to maximize compatibility between usage of EDOT Node.js and the OpenTelemetry JS SDK.
+
+## Native instrumentations
+
+Native instrumentation refers to OpenTelemetry instrumentation that is built into a library. When a library includes native OTel instrumentation, it provides telemetry data to providers registered by a running OTel SDK. Native instrumentations of note are listed in the following table. To benefit from these instrumentations you only need to use the library and start the EDOT Node.js SDK:
+
+```bash
+node --import @elastic/opentelemetry-node my-app.js
+```
+
+| Packages instrumented | Reference |
+|---|---|
+| `@elastic/elasticsearch` version range `>=8.15.0` | {{es}} JavaScript Client docs |
+
+## ECMAScript Modules (ESM)
+
+EDOT Node.js includes limited and experimental support for instrumenting [ECMAScript module (ESM) imports](https://nodejs.org/api/esm.html#modules-ecmascript-modules). For example modules that are loaded through `import ...` statements and `import('...')` (dynamic import).
+
+To activate ESM instrumentation, use `node --import @elastic/opentelemetry-node ...` to start the SDK. Using `node --require @elastic/opentelemetry-node ...` does not turn on ESM instrumentation. It is intended to signal that only CommonJS module usage should be instrumented.
+
+### Limitations
+
+The following limitations apply to ESM instrumentation:
+
+* ESM instrumentation is only supported for Node.js versions `^18.19.0 || >=20.6.0`. These are the versions that include `module.register()` support. Using the older `node --experimental-loader=...` option is not supported.
+* Currently, only a subset of instrumentations support ESM: `express`, `ioredis`, `koa`, `pg`, `pino`. Refer to [this OpenTelemetry JS tracking issue](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1942) for progress.

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -1,0 +1,10 @@
+toc:
+      - file: index.md
+        children:
+          - file: setup/index.md
+            children:
+              - file: setup/k8s.md
+          - file: configuration.md
+          - file: supported-technologies.md
+          - file: metrics.md
+          - file: migration.md

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -8,3 +8,5 @@ toc:
           - file: supported-technologies.md
           - file: metrics.md
           - file: migration.md
+          - title: Troubleshooting
+            crosslink: docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/nodejs/index.md


### PR DESCRIPTION
This PR contributes to https://github.com/elastic/opentelemetry-dev/issues/1044

It brings back the reference documentation and adds a nav crosslink to the troubleshooting docs.

We're assuming here that the EDOT Collector documentation will be served from the `main` branch, following cumulative docs best practices.