### PR TITLE
Add cooldown period for npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 10
     ignore:
       # undici@7 dropped Node.js 18 support
@@ -39,7 +39,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 10
     groups:
       mockotlpserver:
@@ -51,7 +51,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 10
     ignore:
       # uuid@12 dropped CommonJS support (https://github.com/uuidjs/uuid/issues/881)
@@ -67,7 +67,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 10
     ignore:
       # undici@7 dropped Node.js 18 support
@@ -86,7 +86,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 10
     ignore:
       # Locked to the same version being used by opentelemetry-js-contrib.
@@ -111,7 +111,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 10
     ignore:
       # eslint-related deps are skipped until we have upgraded to eslint@9
@@ -139,7 +139,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     directory: "/packages/opentelemetry-node"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 10
     ignore:
       # undici@7 dropped Node.js 18 support
@@ -36,6 +38,8 @@ updates:
     directory: "/packages/mockotlpserver"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 10
     groups:
       mockotlpserver:
@@ -46,6 +50,8 @@ updates:
     directory: "/packages/mockopampserver"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 10
     ignore:
       # uuid@12 dropped CommonJS support (https://github.com/uuidjs/uuid/issues/881)
@@ -60,6 +66,8 @@ updates:
     directory: "/packages/opamp-client-node"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 10
     ignore:
       # undici@7 dropped Node.js 18 support
@@ -77,6 +85,8 @@ updates:
     directory: "/packages/instrumentation-openai"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 10
     ignore:
       # Locked to the same version being used by opentelemetry-js-contrib.
@@ -100,6 +110,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 10
     ignore:
       # eslint-related deps are skipped until we have upgraded to eslint@9
@@ -126,6 +138,8 @@ updates:
     directory: "/examples"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
 Dependabot is configured per repo so we need your help to ensure that when “npm” is the package ecosystem that we set a cooldown to 14 days. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown- 

