### PR TITLE
chore: prepare release workflows for trusted publishing

### DIFF
--- a/.github/workflows/release-instrumentation-openai.yml
+++ b/.github/workflows/release-instrumentation-openai.yml
@@ -6,12 +6,10 @@ on:
     tags:
       - instrumentation-openai-v*.*.*
 
-# 'id-token' perm needed for npm publishing with provenance (see
-# https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)
 permissions:
-  contents: write
   pull-requests: read
-  id-token: write
+  contents: write # Required for "GitHub release" step
+  id-token: write # Required for OIDC and provenance (npm publish)
 
 jobs:
   release:
@@ -26,10 +24,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 'v18.20.4'
+          # Require npm 11.5.1 or later for https://docs.npmjs.com/trusted-publishers.
+          node-version: 'v24.8.0'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
         working-directory: ${{ env.PKGDIR }}
 
       - run: npm run compile
@@ -37,13 +36,10 @@ jobs:
 
       - run: npm publish
         working-directory: ${{ env.PKGDIR }}
-        env:
-          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: GitHub release
         run: |
-          npm ci  # need top-level devDeps for github-release.sh script
+          npm ci --ignore-scripts  # need top-level devDeps for github-release.sh script
           ./scripts/github-release.sh "$PKGDIR" "${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-mockopampserver.yml
+++ b/.github/workflows/release-mockopampserver.yml
@@ -7,19 +7,15 @@ on:
       - mockopampserver-v*.*.*
 
 permissions:
-  contents: read
+  pull-requests: read
+  contents: write # Required for "GitHub release" step
+  packages: write # Required for ghcr.io publish? https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions
+  id-token: write # Required for OIDC and provenance (npm publish)
+  attestations: write # Required for actions/attest-build-provenance
 
 jobs:
   release:
     runs-on: ubuntu-24.04
-    permissions:
-      attestations: write
-      contents: write
-      packages: write
-      pull-requests: read
-      # 'id-token' perm needed for npm publishing with provenance (see
-      # https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)
-      id-token: write
     env:
       PKGDIR: packages/mockopampserver
       PKGNAME: "@elastic/mockopampserver"
@@ -31,7 +27,8 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 'v22.16.0'
+          # Require npm 11.5.1 or later for https://docs.npmjs.com/trusted-publishers.
+          node-version: 'v24.8.0'
           registry-url: 'https://registry.npmjs.org'
 
       # Multiple steps to push a docker image.
@@ -73,13 +70,10 @@ jobs:
 
       - run: npm publish
         working-directory: ${{ env.PKGDIR }}
-        env:
-          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: GitHub release
         run: |
-          npm ci  # need top-level devDeps for github-release.sh script
+          npm ci --ignore-scripts  # need top-level devDeps for github-release.sh script
           ./scripts/github-release.sh "$PKGDIR" "${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-mockotlpserver.yml
+++ b/.github/workflows/release-mockotlpserver.yml
@@ -6,14 +6,12 @@ on:
     tags:
       - mockotlpserver-v*.*.*
 
-# 'id-token' perm needed for npm publishing with provenance (see
-# https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)
 permissions:
-  attestations: write
-  contents: write
-  packages: write
   pull-requests: read
-  id-token: write
+  contents: write # Required for "GitHub release" step
+  packages: write # Required for ghcr.io publish? https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions
+  id-token: write # Required for OIDC and provenance (npm publish)
+  attestations: write # Required for actions/attest-build-provenance
 
 jobs:
   release:
@@ -29,7 +27,8 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 'v18.20.4'
+          # Require npm 11.5.1 or later for https://docs.npmjs.com/trusted-publishers.
+          node-version: 'v24.8.0'
           registry-url: 'https://registry.npmjs.org'
 
       # Push a Docker image.
@@ -71,13 +70,10 @@ jobs:
 
       - run: npm publish
         working-directory: ${{ env.PKGDIR }}
-        env:
-          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: GitHub release
         run: |
-          npm ci  # need top-level devDeps for github-release.sh script
+          npm ci --ignore-scripts  # need top-level devDeps for github-release.sh script
           ./scripts/github-release.sh "$PKGDIR" "${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-opamp-client-node.yml
+++ b/.github/workflows/release-opamp-client-node.yml
@@ -7,17 +7,13 @@ on:
       - opamp-client-node-v*.*.*
 
 permissions:
-  contents: read
+  pull-requests: read
+  contents: write # Required for "GitHub release" step
+  id-token: write # Required for OIDC and provenance (npm publish)
 
 jobs:
   release:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-      pull-requests: read
-      # 'id-token' perm needed for npm publishing with provenance (see
-      # https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)
-      id-token: write
     env:
       PKGDIR: packages/opamp-client-node
       PKGNAME: "@elastic/opamp-client-node"
@@ -28,21 +24,16 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 'v18.20.4'
+          # Require npm 11.5.1 or later for https://docs.npmjs.com/trusted-publishers.
+          node-version: 'v24.8.0'
           registry-url: 'https://registry.npmjs.org'
-
-      - run: npm ci
-        working-directory: ${{ env.PKGDIR }}
 
       - run: npm publish
         working-directory: ${{ env.PKGDIR }}
-        env:
-          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: GitHub release
         run: |
-          npm ci  # need top-level devDeps for github-release.sh script
+          npm ci --ignore-scripts  # need top-level devDeps for github-release.sh script
           ./scripts/github-release.sh "$PKGDIR" "${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           # Require npm 11.5.1 or later for https://docs.npmjs.com/trusted-publishers.
           node-version: 'v24.8.0'
+          registry-url: 'https://registry.npmjs.org'
 
       # Setup a Docker "buildx" builder container, used by "build-push-action"
       # below for multi-platform image builds. Notes on multi-platform images:
@@ -91,7 +92,7 @@ jobs:
       - name: GitHub release (only for tag releases)
         if: startsWith(github.ref, 'refs/tags')
         run: |
-          npm ci  # need top-level devDeps for github-release.sh script
+          npm ci --ignore-scripts  # need top-level devDeps for github-release.sh script
           ./scripts/github-release.sh "packages/opentelemetry-node" "${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- Attempt to doc why each permission is needed.
- Ensure sufficient npm version for OIDC, drop usage of NPM_TOKEN.

Also, unrelated to trusted publishing but related to release hardening,
I've dropped 'npm ci' where I thikn the release doesn't need it and
added --ignore-scripts to all 'npm ci' calls because I think postinstall
scripts are not needed for our *releases*. It is possible this will
break release of one of these components, but we can solve that
at their next release.

Refs: https://github.com/elastic/elastic-otel-node/issues/1041
