### PR TITLE
chore: revert node version bump in Dockerfile in packages/opentelemetry-node

### DIFF
--- a/packages/opentelemetry-node/Dockerfile
+++ b/packages/opentelemetry-node/Dockerfile
@@ -16,7 +16,7 @@
 # Typically the build is handled by CI, which also adds other build tags,
 # handles provenance, etc.
 
-FROM node:25 AS build
+FROM node:24 AS build
 
 WORKDIR /build/src
 COPY ./packages/opentelemetry-node/ /build/src/packages/opentelemetry-node/


### PR DESCRIPTION
This PR reverts https://github.com/elastic/elastic-otel-node/pull/1099

cc: @trentm 