### PR TITLE
chore: set minor version for grouping aws sdk updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,8 @@ updates:
         patterns:
         - "@aws-sdk/*"
         - "@smithy/*"
+        update-types:
+        - "minor"
       patch-level:
         update-types:
         - "patch"


### PR DESCRIPTION
This PR is an attempt to better grouping AWS SDK updates. As for now we get grouped updates sometimes but usually we get a single PR to update each client. Examples:
- https://github.com/elastic/elastic-otel-node/pull/1091
- https://github.com/elastic/elastic-otel-node/pull/1089
- https://github.com/elastic/elastic-otel-node/pull/1087

were created the same day.

I noticed the clients usually bump the minor version instead of the patch. It's clear in the [releases GH page](https://github.com/aws/aws-sdk-js-v3/releases). This PR adds the `minor` [update type](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#update-types-groups) for the `aws-sdk` group.