### PR TITLE
chore: stick to Node.js v24 for docker images

### DIFF
--- a/examples/otel-operator/Dockerfile
+++ b/examples/otel-operator/Dockerfile
@@ -2,7 +2,7 @@
 #    docker build -t myapp .
 #    docker run --rm -it -p 3000:3000 myapp
 #    curl -i http://127.0.0.1:3000/ping
-FROM node:25-alpine
+FROM node:24-alpine
 RUN mkdir /app
 WORKDIR /app
 COPY app.js package.json ./

--- a/packages/mockopampserver/Dockerfile
+++ b/packages/mockopampserver/Dockerfile
@@ -3,7 +3,7 @@
 # Usage for local development:
 #   docker build -t mockopampserver .
 #   docker run --rm -it -p 4320:4320 --name mockopampserver mockopampserver
-FROM node:25-alpine
+FROM node:24-alpine
 RUN mkdir /app
 WORKDIR /app
 COPY lib ./lib/

--- a/packages/mockotlpserver/Dockerfile
+++ b/packages/mockotlpserver/Dockerfile
@@ -3,7 +3,7 @@
 #   docker run --rm -it -p 4317:4317 -p 4318:4318 --name mockotlpserver mockotlpserver
 #
 # Or see "share/k8s/README.md" for using it with Kubernetes.
-FROM node:25-alpine
+FROM node:24-alpine
 RUN mkdir /app
 WORKDIR /app
 COPY lib ./lib/

--- a/packages/mockotlpserver/share/k8s/example-app-manual/Dockerfile
+++ b/packages/mockotlpserver/share/k8s/example-app-manual/Dockerfile
@@ -2,7 +2,7 @@
 #    docker build -t example-app-manual .
 #    docker run --rm -it -p 3000:3000 example-app-manual
 #    curl -i http://127.0.0.1:3000/ping
-FROM node:25-alpine
+FROM node:24-alpine
 RUN mkdir /app
 WORKDIR /app
 COPY app.js package.json ./


### PR DESCRIPTION
Node.js 25 is part of the shorter-lived odd-numbered set.
Let's stick with v24 for our published images, also even for
examples.

This reverts a few recent dependabot changes.
