### PR TITLE
release mockopampserver 0.4.1

### DIFF
--- a/packages/mockopampserver/CHANGELOG.md
+++ b/packages/mockopampserver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/mockopampserver Changelog
 
-## Unreleased
+## v0.4.1
 
 - Fix an edge case where the server could crash on receiving a AgentToServer
   with an `instance_uid` that could not be stringified to a valid UUID.

--- a/packages/mockopampserver/package-lock.json
+++ b/packages/mockopampserver/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/mockopampserver",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/mockopampserver",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",

--- a/packages/mockopampserver/package.json
+++ b/packages/mockopampserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/mockopampserver",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "commonjs",
   "description": "A mock OpAMP server, useful for dev and testing",
   "publishConfig": {


### PR DESCRIPTION
Contains a fix for a crash in certain situations. https://github.com/elastic/elastic-otel-node/pull/1068