### PR TITLE
fix(mockotlpserver): validate dynamic action names and guard calls

### DIFF
--- a/packages/mockotlpserver/lib/http.js
+++ b/packages/mockotlpserver/lib/http.js
@@ -225,7 +225,15 @@ class HttpService extends Service {
                 // same context).
                 // https://nodejs.org/api/diagnostics_channel.html#channelpublishmessage
                 // TODO: maybe surround with try/catch to not blow up the server?
-                const parseData = parsersMap[contentType] || unknownParser;
+                let parseData;
+                if (
+                    Object.prototype.hasOwnProperty.call(parsersMap, contentType) &&
+                    typeof parsersMap[contentType] === 'function'
+                ) {
+                    parseData = parsersMap[contentType];
+                } else {
+                    parseData = unknownParser;
+                }
                 const reqBuffer = Buffer.concat(chunks);
                 const reqUrl = req.url;
                 const data = parseData(log, reqBuffer, req);


### PR DESCRIPTION
fix for #1133

To prevent security or runtime issues from unvalidated dynamic method lookup, we should ensure that:
1. The property is an *own* property of `parsersMap` (not from the prototype chain).
2. The value retrieved from `parsersMap` is a *function* before invoking it.

This can be addressed by replacing the direct dynamic call to `parsersMap[contentType]`, and ensuring with two checks:
- Use `.hasOwnProperty(contentType)` to confirm it is an own property,
- Use `typeof parsersMap[contentType] === 'function'` to confirm it resolves to a function.

Alternatively, if `parsersMap` is never reassigned, it would be even safer to create it as an object without a prototype (e.g., `Object.create(null)`) or as a `Map` (but we cannot edit that from the current context). The best minimal fix given the context is to update the code inside the `'end'` handler function, from the assignment and use of `parseData`, to ensure these checks are made before calling `parseData`. If validation fails, we can fall back to `unknownParser` as it currently does.