### PR TITLE
fix(mockopampserver): workaround possible exception in logging

### DIFF
--- a/packages/mockopampserver/lib/logging.js
+++ b/packages/mockopampserver/lib/logging.js
@@ -49,6 +49,11 @@ function createLogger() {
                 // on.
                 return util.inspect(agent, {depth: 50, colors: true});
             },
+            sequenceNum: function (sequenceNum) {
+                // Workaround Bunyan's geriatric serialization choking on
+                // BigInts. This is, of course, a weak workaround.
+                return util.inspect(sequenceNum);
+            },
         },
         level: 'info',
         stream: process.stdout,

--- a/packages/mockopampserver/lib/mockopampserver.js
+++ b/packages/mockopampserver/lib/mockopampserver.js
@@ -714,7 +714,7 @@ class MockOpAMPServer {
                 !reportedFullState
             ) {
                 log.debug(
-                    {instanceUidStr, agentSeqNum: agent.sequenceNum},
+                    {instanceUidStr, sequenceNum: agent.sequenceNum},
                     'request ReportFullState (sequenceNum missed)'
                 );
                 resData.flags |=


### PR DESCRIPTION
Bunyan's geriatric serialization cannot cope with new-fangled BigInts,
so we need to avoid logging them (lame), or coping via serializers
(not much better).
