### PR TITLE
release opamp-client-node v0.4.0

### DIFF
--- a/packages/opamp-client-node/package-lock.json
+++ b/packages/opamp-client-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opamp-client-node",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opamp-client-node",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",


### PR DESCRIPTION
I missed updating package-lock in earlier commit.
