### PR TITLE
chore(opentelemetry-node): update deps matching "@opentelemetry/*"

### DIFF
--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -46,7 +46,7 @@
         "@opentelemetry/instrumentation-mysql2": "^0.55.0",
         "@opentelemetry/instrumentation-nestjs-core": "^0.55.0",
         "@opentelemetry/instrumentation-net": "^0.52.0",
-        "@opentelemetry/instrumentation-openai": "^0.6.0",
+        "@opentelemetry/instrumentation-openai": "^0.7.0",
         "@opentelemetry/instrumentation-oracledb": "^0.34.0",
         "@opentelemetry/instrumentation-pg": "^0.61.0",
         "@opentelemetry/instrumentation-pino": "^0.55.0",
@@ -4511,9 +4511,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.53.0.tgz",
-      "integrity": "sha512-xngn5cH2mVXFmiT1XfQ1aHqq1m4xb5wvU6j9lSgLlihJ1bXzsO543cpDwjrZm2nMrlpddBf55w8+bfS4qDh60g==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.53.1.tgz",
+      "integrity": "sha512-tIW3gqVC8d9CCE+oxPO63WNvC+5PKC/LrPrYWFobii5afUpHJV+0pfyt08okAFBHztzT0voMOEPGkLKoacZRXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.208.0",
@@ -4671,9 +4671,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-openai": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-openai/-/instrumentation-openai-0.6.0.tgz",
-      "integrity": "sha512-FmmAi+gwuAyoWkxuyqpFlBCi7YG36L3HLnLVE0gf2iZV+AQlVQgd9kP8SxywSPV1L9BqTwJJ8mDIUiIBp9zSAQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-openai/-/instrumentation-openai-0.7.0.tgz",
+      "integrity": "sha512-p6quVxFL3q1qwrjNtpOmeaesjjdjWcdvkRFrRyqvg4zHYhiZF7+Als3tsYtvBwQElycnxDwtSAh7E2kbQk2NkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "^0.208.0",
@@ -4705,9 +4705,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.61.0.tgz",
-      "integrity": "sha512-UeV7KeTnRSM7ECHa3YscoklhUtTQPs6V6qYpG283AB7xpnPGCUCUfECFT9jFg6/iZOQTt3FHkB1wGTJCNZEvPw==",
+      "version": "0.61.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.61.1.tgz",
+      "integrity": "sha512-VKKts/XcOCa7IPBxVjL2B4UyG+YTNa4Dh1Xx2vqL0jOEQBJlNsv++I12BUw/8NRLEr2K/gOM5tpVU7QqhWA65A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -4742,9 +4742,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.57.0.tgz",
-      "integrity": "sha512-bCxTHQFXzrU3eU1LZnOZQ3s5LURxQPDlU3/upBzlWY77qOI1GZuGofazj3jtzjctMJeBEJhNwIFEgRPBX1kp/Q==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.57.1.tgz",
+      "integrity": "sha512-iP564P8On9NPPi06T2MyL56sBN0RsF29DX/RC5fW0yOOFdUHcvCDmJnp11eZyymTvYj5HX8tvpoO+vDb6+Lv8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.208.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -110,7 +110,7 @@
     "@opentelemetry/instrumentation-mysql2": "^0.55.0",
     "@opentelemetry/instrumentation-nestjs-core": "^0.55.0",
     "@opentelemetry/instrumentation-net": "^0.52.0",
-    "@opentelemetry/instrumentation-openai": "^0.6.0",
+    "@opentelemetry/instrumentation-openai": "^0.7.0",
     "@opentelemetry/instrumentation-oracledb": "^0.34.0",
     "@opentelemetry/instrumentation-pg": "^0.61.0",
     "@opentelemetry/instrumentation-pino": "^0.55.0",


### PR DESCRIPTION
Summary of changes:

    0.6.0 -> 0.7.0 @opentelemetry/instrumentation-openai (range-bump)
    0.53.0 -> 0.53.1 @opentelemetry/instrumentation-knex
    0.57.0 -> 0.57.1 @opentelemetry/instrumentation-redis
    0.61.0 -> 0.61.1 @opentelemetry/instrumentation-pg

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3242 (p1 bug in instr-openai)