### PR TITLE
release @elastic/opentelemetry-node@1.14.0

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -29,6 +29,15 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [edot-node-X.X.X-fixes]
 % *
 
+## 1.14.0 [edot-node-1.14.0-release-notes]
+
+### Chores [edot-node-1.14.0-chores]
+
+* Update all `@opentelemetry/*` upstream package dependencies to the latest releases:
+    - [`experimental/v0.218.0` release](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.218.0) from opentelemetry-js
+    - [opentelemetry-js-contrib release](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3508)
+    - This includes a security fix to the exporters (removing the dependency on protobufjs@8.0.1).
+
 ## 1.13.0 [edot-node-1.13.0-release-notes]
 
 ### Chores [edot-node-1.13.0-chores]

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elastic/opentelemetry-node",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/opamp-client-node": "^0.4.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/opentelemetry-node",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "type": "commonjs",
   "description": "Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js)",
   "publishConfig": {


### PR DESCRIPTION
This updates upstream OTel deps, which include a security fix for a protobufjs vulnerability.