### PR TITLE
perf(opentelemetry-node): use HostMetrics 'metricGroups' to select the metrics we want to collect, rather than collecting too many and using a Metric view to drop them

### DIFF
--- a/packages/opentelemetry-node/lib/sdk.js
+++ b/packages/opentelemetry-node/lib/sdk.js
@@ -28,7 +28,6 @@ const {
     ConsoleLogRecordExporter,
     SimpleLogRecordProcessor,
 } = require('@opentelemetry/sdk-logs');
-const {AggregationType} = require('@opentelemetry/sdk-metrics');
 const {HostMetrics} = require('@opentelemetry/host-metrics');
 
 const {createAddHookMessageChannel} = require('import-in-the-middle');

--- a/packages/opentelemetry-node/lib/sdk.js
+++ b/packages/opentelemetry-node/lib/sdk.js
@@ -238,20 +238,6 @@ function startNodeSDK(cfg = {}) {
     const metricsExporters = getStringListFromEnv('OTEL_METRICS_EXPORTER');
     const metricsEnabled = metricsExporters.every((e) => e !== 'none');
 
-    if (metricsEnabled) {
-        // Set the views conditionally so the upstream SDK does not create meter provider for nothing
-        defaultConfig.views = [
-            // Dropping system metrics because:
-            // - sends a lot of data. Ref: https://github.com/elastic/elastic-otel-node/issues/51
-            // - not displayed by Kibana in metrics dashboard. Ref: https://github.com/elastic/kibana/pull/199353
-            // - recommendation is to use OTEL collector to get and export them
-            {
-                instrumentName: 'system.*',
-                aggregation: {type: AggregationType.DROP},
-            },
-        ];
-    }
-
     const config = {...defaultConfig, ...cfg};
 
     /** @type {Sampler} */
@@ -297,7 +283,13 @@ function startNodeSDK(cfg = {}) {
         'ELASTIC_OTEL_HOST_METRICS_DISABLED'
     );
     if (metricsEnabled && !hostMetricsDisabled) {
-        const hostMetricsInstance = new HostMetrics();
+        // Excluding `system.*` metrics because:
+        // - sends a lot of data. Ref: https://github.com/elastic/elastic-otel-node/issues/51
+        // - not displayed by Kibana in metrics dashboard. Ref: https://github.com/elastic/kibana/pull/199353
+        // - recommendation is to use OTEL collector to get and export them
+        const hostMetricsInstance = new HostMetrics({
+            metricGroups: ['process.cpu', 'process.memory']
+        });
         hostMetricsInstance.start();
     }
 

--- a/packages/opentelemetry-node/lib/sdk.js
+++ b/packages/opentelemetry-node/lib/sdk.js
@@ -287,7 +287,7 @@ function startNodeSDK(cfg = {}) {
         // - not displayed by Kibana in metrics dashboard. Ref: https://github.com/elastic/kibana/pull/199353
         // - recommendation is to use OTEL collector to get and export them
         const hostMetricsInstance = new HostMetrics({
-            metricGroups: ['process.cpu', 'process.memory']
+            metricGroups: ['process.cpu', 'process.memory'],
         });
         hostMetricsInstance.start();
     }

--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -65,7 +65,6 @@
         "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/sampler-composite": "^0.218.0",
         "@opentelemetry/sdk-logs": "^0.218.0",
-        "@opentelemetry/sdk-metrics": "2.7.1",
         "@opentelemetry/sdk-node": "^0.218.0",
         "@opentelemetry/semantic-conventions": "^1.30.0",
         "@opentelemetry/winston-transport": "^0.28.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -131,7 +131,6 @@
     "@opentelemetry/resources": "2.7.1",
     "@opentelemetry/sampler-composite": "^0.218.0",
     "@opentelemetry/sdk-logs": "^0.218.0",
-    "@opentelemetry/sdk-metrics": "2.7.1",
     "@opentelemetry/sdk-node": "^0.218.0",
     "@opentelemetry/semantic-conventions": "^1.30.0",
     "@opentelemetry/winston-transport": "^0.28.0",


### PR DESCRIPTION
Support for 'metricGroups' was added a while back in:
https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3149
