### PR TITLE
chore(ci): ensure explicitly list permissions on all workflows

### DIFF
--- a/.github/workflows/slack-lite.yml
+++ b/.github/workflows/slack-lite.yml
@@ -22,6 +22,9 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, reopened, closed]
 
+permissions:
+  contents: read
+
 jobs:
   slack-lite:
     # Skip notification if:


### PR DESCRIPTION
This avoids relying on default GITHUB_TOKEN permissions, which
might include write perms. See
https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/
