### PR TITLE
ci: fix typo in permission-contents field

### DIFF
--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -18,7 +18,7 @@ jobs:
           client-id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
           # Perms required by "Create PR" step below.
-          permission-context: write
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Checkout


### PR DESCRIPTION
https://github.com/elastic/elastic-otel-node/actions/runs/28677781856/job/85054731182 failed with:

```
Unexpected input(s) 'permission-context', valid inputs are ['client-id', ' ...
```