### PR TITLE
ci: ensure update-otel-deps.js has its own deps to run

### DIFF
--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -34,6 +34,9 @@ jobs:
           cache-dependency-path: package-lock.json
           node-version: 24
 
+      # Needed for the deps used by scripts/update-otel-deps.js.
+      - run: npm ci --ignore-scripts
+
       - run: npm ci --ignore-scripts
         working-directory: packages/opentelemetry-node
 


### PR DESCRIPTION
https://github.com/elastic/elastic-otel-node/actions/runs/28678042808/job/85055508016 failed with:

```

Error: Cannot find module 'minimatch'
Require stack:
- /home/runner/work/elastic-otel-node/elastic-otel-node/scripts/update-otel-deps.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1517:15)
...
```