### PR TITLE
docs: rename EDOT to Elastic OTel Node.js for 9.5 rebrand

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,4 @@
-project: 'EDOT Node.js release notes'
+project: 'Elastic OTel Node.js release notes'
 cross_links:
   - docs-content
   - opentelemetry
@@ -10,7 +10,7 @@ toc:
   - toc: reference/edot-node
 subs:
   motlp: Elastic Cloud Managed OTLP Endpoint
-  edot:    "Elastic Distribution of OpenTelemetry"
+  edot:    "Elastic OpenTelemetry"
   ecloud:   "Elastic Cloud"
   ech:   "Elastic Cloud Hosted"
   ess:   "Elasticsearch Service"

--- a/docs/reference/edot-node/configuration.md
+++ b/docs/reference/edot-node/configuration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Configuration
-description: How to configure the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js) using environment variables.
+description: How to configure the Elastic OTel Node.js using environment variables.
 applies_to:
   stack:
   serverless:
@@ -13,14 +13,14 @@ products:
   - id: edot-sdk
 ---
 
-# Configure the EDOT Node.js SDK
+# Configure the Elastic OTel Node.js SDK [configure-the-edot-nodejs-sdk]
 
-The {{edot}} Node.js (EDOT Node.js) is configured with environment variables beginning with `OTEL_` or `ELASTIC_OTEL_`. Any `OTEL_*` environment variables behave the same as with the OpenTelemetry SDK. For example, all the OpenTelemetry [General SDK Configuration env vars](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) are supported. If EDOT Node.js provides a configuration setting specific to the Elastic distribution, it will begin with `ELASTIC_OTEL_`.
+The {{edot}} Node.js is configured with environment variables beginning with `OTEL_` or `ELASTIC_OTEL_`. Any `OTEL_*` environment variables behave the same as with the OpenTelemetry SDK. For example, all the OpenTelemetry [General SDK Configuration env vars](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) are supported. If Elastic OTel Node.js provides a configuration setting specific to the Elastic distribution, it will begin with `ELASTIC_OTEL_`.
 
 
 ## Basic configuration
 
-If not configured, EDOT Node.js will send telemetry data to `http://localhost:4318` with no authentication information, and identify the running service as `unknown_service:node`. Typically a minimal configuration will include
+If not configured, Elastic OTel Node.js will send telemetry data to `http://localhost:4318` with no authentication information, and identify the running service as `unknown_service:node`. Typically a minimal configuration will include
 
 * `OTEL_EXPORTER_OTLP_ENDPOINT`: The full URL of an OpenTelemetry Collector where data will be sent.
 * `OTEL_EXPORTER_OTLP_HEADERS`: A comma-separated list of HTTP headers used for exporting data, typically used to set the `Authorization` header with auth information.
@@ -37,13 +37,13 @@ export OTEL_SERVICE_NAME=my-app
 
 ## Configuration reference
 
-This section attempts to list all environment variables that can be used to configure EDOT Node.js. Some settings also have a section below discussing behavior that is interesting and/or specific to EDOT Node.js.
+This section attempts to list all environment variables that can be used to configure Elastic OTel Node.js. Some settings also have a section below discussing behavior that is interesting and/or specific to Elastic OTel Node.js.
 
 :::{warning}
-The behavior of `OTEL_` environment variables are typically defined by OpenTelemetry dependencies of EDOT Node.js. In some cases, these dependencies have a "development" status (`0.x` versions). This means that their behavior can be broken in a minor release of EDOT Node.js.
+The behavior of `OTEL_` environment variables are typically defined by OpenTelemetry dependencies of Elastic OTel Node.js. In some cases, these dependencies have a "development" status (`0.x` versions). This means that their behavior can be broken in a minor release of Elastic OTel Node.js.
 :::
 
-The 🔹 symbol denotes settings with a default value or behavior that differs between EDOT Node.js and OTel JS, or that only exists in EDOT Node.js.
+The 🔹 symbol denotes settings with a default value or behavior that differs between Elastic OTel Node.js and OTel JS, or that only exists in Elastic OTel Node.js.
 
 | Name | Notes |
 | :--- | :---- |
@@ -64,23 +64,23 @@ The 🔹 symbol denotes settings with a default value or behavior that differs b
 | `OTEL_EXPORTER_OTLP_CLIENT_KEY` | [(Ref)][otel-exporter-envvars] Client private key for mTLS communication. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_CLIENT_KEY`. |
 | `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` | [(Ref)][otel-exporter-envvars] The trusted certificate to use when verifying a server's TLS credentials. Also supports signal-specific `OTEL_EXPORTER_OTLP_{signal}_CLIENT_CERTIFICATE`. |
 | | |
-| `OTEL_NODE_RESOURCE_DETECTORS` | [(EDOT Ref)](#otel_node_resource_detectors-details) Comma-separated list of resource detectors to use. |
-| `OTEL_NODE_ENABLED_INSTRUMENTATIONS` 🔹 | [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details) Comma-separated list of instrumentations to turn on. |
-| `OTEL_NODE_DISABLED_INSTRUMENTATIONS` 🔹 | [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details) Comma-separated list of instrumentations to turn off. |
+| `OTEL_NODE_RESOURCE_DETECTORS` | [(Elastic OTel Ref)](#otel_node_resource_detectors-details) Comma-separated list of resource detectors to use. |
+| `OTEL_NODE_ENABLED_INSTRUMENTATIONS` 🔹 | [(Elastic OTel Ref)](#otel_node_disabledenabled_instrumentations-details) Comma-separated list of instrumentations to turn on. |
+| `OTEL_NODE_DISABLED_INSTRUMENTATIONS` 🔹 | [(Elastic OTel Ref)](#otel_node_disabledenabled_instrumentations-details) Comma-separated list of instrumentations to turn off. |
 | | |
-| `ELASTIC_OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS` 🔹  | [(EDOT Ref)](#capture_headers-details) Comma-separated list of HTTP request headers to capture on client spans. |
-| `ELASTIC_OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS` 🔹 | [(EDOT Ref)](#capture_headers-details) Comma-separated list of HTTP response headers to capture on client spans. |
-| `ELASTIC_OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS` 🔹  | [(EDOT Ref)](#capture_headers-details) Comma-separated list of HTTP request headers to capture on server spans. |
-| `ELASTIC_OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS` 🔹  | [(EDOT Ref)](#capture_headers-details) Comma-separated list of HTTP response headers to capture on server spans. |
+| `ELASTIC_OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS` 🔹  | [(Elastic OTel Ref)](#capture_headers-details) Comma-separated list of HTTP request headers to capture on client spans. |
+| `ELASTIC_OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS` 🔹 | [(Elastic OTel Ref)](#capture_headers-details) Comma-separated list of HTTP response headers to capture on client spans. |
+| `ELASTIC_OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS` 🔹  | [(Elastic OTel Ref)](#capture_headers-details) Comma-separated list of HTTP request headers to capture on server spans. |
+| `ELASTIC_OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS` 🔹  | [(Elastic OTel Ref)](#capture_headers-details) Comma-separated list of HTTP response headers to capture on server spans. |
 | | |
-| `ELASTIC_OTEL_HOST_METRICS_DISABLED` 🔹 | [(EDOT Ref)](#elastic_otel_host_metrics_disabled-details) Turn off collection of metrics done by `@opentelemetry/host-metrics` package. |
-| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` 🔹 | [(EDOT Ref)](#otel_exporter_otlp_metrics_temporality_preference-details) The metrics exporter's default aggregation `temporality`. The default value is `delta`. The OTel default is `cumulative`. |
+| `ELASTIC_OTEL_HOST_METRICS_DISABLED` 🔹 | [(Elastic OTel Ref)](#elastic_otel_host_metrics_disabled-details) Turn off collection of metrics done by `@opentelemetry/host-metrics` package. |
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` 🔹 | [(Elastic OTel Ref)](#otel_exporter_otlp_metrics_temporality_preference-details) The metrics exporter's default aggregation `temporality`. The default value is `delta`. The OTel default is `cumulative`. |
 | | |
-| `OTEL_SEMCONV_STABILITY_OPT_IN` 🔹 | [(EDOT Ref)](#otel_semconv_stability_opt_in-details) Control which HTTP semantic conventions are used by `@opentelemetry/instrumentation-http`. The default value is `http`. The OTel default is an empty value. |
-| `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` 🔹 | [(EDOT Ref)](#elastic_otel_context_propagation_only-details) Set to `true` to turn on trace-context propagation in outgoing requests and log correlation. This turns off the sending of spans. |
-| `ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING` 🔹 | [(EDOT Ref)](#elastic_otel_node_enable_log_sending-details) Set to `true` to enable "log sending" in instrumentations of Node.js logging frameworks (pino, bunyan, winston). |
+| `OTEL_SEMCONV_STABILITY_OPT_IN` 🔹 | [(Elastic OTel Ref)](#otel_semconv_stability_opt_in-details) Control which HTTP semantic conventions are used by `@opentelemetry/instrumentation-http`. The default value is `http`. The OTel default is an empty value. |
+| `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` 🔹 | [(Elastic OTel Ref)](#elastic_otel_context_propagation_only-details) Set to `true` to turn on trace-context propagation in outgoing requests and log correlation. This turns off the sending of spans. |
+| `ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING` 🔹 | [(Elastic OTel Ref)](#elastic_otel_node_enable_log_sending-details) Set to `true` to enable "log sending" in instrumentations of Node.js logging frameworks (pino, bunyan, winston). |
 | | |
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | [(EDOT Ref)](#otel_instrumentation_genai_capture_message_content-details) A boolean to control whether message content should be included in GenAI-related telemetry. |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | [(Elastic OTel Ref)](#otel_instrumentation_genai_capture_message_content-details) A boolean to control whether message content should be included in GenAI-related telemetry. |
 | | |
 | `OTEL_BSP_SCHEDULE_DELAY` | [(Ref)][otel-sdk-envvars-bsp] Duration, in milliseconds, between consecutive BatchSpanProcessor exports. The default value is `5000`. |
 | `OTEL_BSP_EXPORT_TIMEOUT` | [(Ref)][otel-sdk-envvars-bsp] Maximum allowed time, in milliseconds, for BatchSpanProcessor to export. The default value is `30000`. |
@@ -119,7 +119,7 @@ The following settings are deprecated:
 
 | Name | Notes |
 | :--- | :---- |
-| `ELASTIC_OTEL_METRICS_DISABLED` 🔹 | [(EDOT Ref)](#deprecated-elastic_otel_metrics_disabled-details) Turn off metrics export and some metrics collection by the SDK. {applies_to}`product: deprecated 1.1.0` |
+| `ELASTIC_OTEL_METRICS_DISABLED` 🔹 | [(Elastic OTel Ref)](#deprecated-elastic_otel_metrics_disabled-details) Turn off metrics export and some metrics collection by the SDK. {applies_to}`product: deprecated 1.1.0` |
 
 ## Central configuration
 
@@ -130,7 +130,7 @@ product:
   edot_node: preview 1.2.0
 ```
 
-APM Agent Central Configuration lets you configure EDOT Node.js instances remotely, see [Central configuration docs](opentelemetry://reference/central-configuration.md) for more details.
+APM Agent Central Configuration lets you configure Elastic OTel Node.js instances remotely, see [Central configuration docs](opentelemetry://reference/central-configuration.md) for more details.
 
 ### Configure central configuration
 
@@ -151,7 +151,7 @@ The following environment variable can be used to configure requests send to the
 
 ### Central configuration settings
 
-You can modify the following settings for EDOT Node.js through APM Agent Central Configuration:
+You can modify the following settings for Elastic OTel Node.js through APM Agent Central Configuration:
 
 | Setting | Central configuration name | Type |
 |---------|--------------------------|------|
@@ -166,13 +166,13 @@ You can modify the following settings for EDOT Node.js through APM Agent Central
 
 Dynamic settings can be changed without having to restart the application.
 
-## EDOT configuration details
+## Elastic OTel configuration details [edot-configuration-details]
 
-This section includes additional details on some configuration settings that merit more explanation, or that have behavior that differs in EDOT Node.js when compared to OpenTelemetry JS.
+This section includes additional details on some configuration settings that merit more explanation, or that have behavior that differs in Elastic OTel Node.js when compared to OpenTelemetry JS.
 
 ### `OTEL_NODE_RESOURCE_DETECTORS` details [otel_node_resource_detectors-details]
 
-A comma-separated list of named resource detectors to use. EDOT Node.js supports the same set as the [`@opentelemetry/auto-instrumentations-node`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/auto-instrumentations-node/README.md#usage-auto-instrumentation):
+A comma-separated list of named resource detectors to use. Elastic OTel Node.js supports the same set as the [`@opentelemetry/auto-instrumentations-node`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/auto-instrumentations-node/README.md#usage-auto-instrumentation):
 
 - `env`
 - `host`
@@ -193,7 +193,7 @@ The "cloud" resource detectors (`alibaba`, `aws`, `azure`, `gcp`) typically make
 export OTEL_NODE_RESOURCE_DETECTORS=env,host,os,process,serviceinstance,container
 ```
 
-In addition, EDOT Node.js always includes the [`telemetry.distro.*` resource attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/telemetry/).
+In addition, Elastic OTel Node.js always includes the [`telemetry.distro.*` resource attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/telemetry/).
 
 :::{note}
 {{kib}} relies on the `service.instance.id` resource attribute to query and break down data to be shown in [service metrics](docs-content://solutions/observability/apm/metrics-ui.md). If you turn off the `serviceinstance` resource detector, the dashboard won't display any data.
@@ -209,7 +209,7 @@ In addition, EDOT Node.js always includes the [`telemetry.distro.*` resource att
 
 The default set of enabled instrumentations is [the set of included instrumentations](/reference/edot-node/supported-technologies.md#instrumentations), minus any that are noted as ["disabled by default"](/reference/edot-node/supported-technologies.md#disabled-instrumentations).
 
-EDOT Node.js handles these settings the same as the [`@opentelemetry/auto-instrumentations-node`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/auto-instrumentations-node/README.md#usage-auto-instrumentation), with one addition. In `@opentelemetry/auto-instrumentations-node`, the name of an instrumentation is the name of the package with the `@opentelemetry/instrumentation-` prefix removed -- `cassandra-driver` refers to the instrumentation provided by `@opentelemetry/instrumentation-cassandra`. EDOT Node.js can include instrumentations that do not have this prefix, for example `@elastic/opentelemetry-instrumentation-SOMETHING`, if/when Elastic includes additional instrumentations that do not match `@opentelemetry/instrumentation-*`. In these cases, the "name" for the instrumentation is the full package name.
+Elastic OTel Node.js handles these settings the same as the [`@opentelemetry/auto-instrumentations-node`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/auto-instrumentations-node/README.md#usage-auto-instrumentation), with one addition. In `@opentelemetry/auto-instrumentations-node`, the name of an instrumentation is the name of the package with the `@opentelemetry/instrumentation-` prefix removed -- `cassandra-driver` refers to the instrumentation provided by `@opentelemetry/instrumentation-cassandra`. Elastic OTel Node.js can include instrumentations that do not have this prefix, for example `@elastic/opentelemetry-instrumentation-SOMETHING`, if/when Elastic includes additional instrumentations that do not match `@opentelemetry/instrumentation-*`. In these cases, the "name" for the instrumentation is the full package name.
 
 ### `ELASTIC_OTEL_INSTRUMENTATION_HTTP_{CLIENT,SERVER}_CAPTURE_{REQUEST,RESPONSE}_HEADERS` details [capture_headers-details]
 
@@ -235,8 +235,8 @@ product:
 Setting `ELASTIC_OTEL_METRICS_DISABLED` to `true` turns off metrics export by the SDK and some metrics collection. This configuration setting is deprecated as of v1.1.0 in favor of using the following settings for finer control:
 
 - To turn off the export of all metrics, set the `OTEL_METRICS_EXPORTER` environment variable to `none`.
-- To turn off collection by the `@opentelemetry/instrumentation-runtime-node` package, set the `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` environment variable to exclude that instrumentation. For example, `OTEL_NODE_DISABLED_INSTRUMENTATIONS=runtime-node`. [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details)
-- To turn off metrics collection by the `@opentelemetry/instrumentation-host-metrics` package, set the `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` environment variable to exclude that instrumentation. For example, `OTEL_NODE_DISABLED_INSTRUMENTATIONS=host-metrics`. [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details)
+- To turn off collection by the `@opentelemetry/instrumentation-runtime-node` package, set the `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` environment variable to exclude that instrumentation. For example, `OTEL_NODE_DISABLED_INSTRUMENTATIONS=runtime-node`. [(Elastic OTel Ref)](#otel_node_disabledenabled_instrumentations-details)
+- To turn off metrics collection by the `@opentelemetry/instrumentation-host-metrics` package, set the `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` environment variable to exclude that instrumentation. For example, `OTEL_NODE_DISABLED_INSTRUMENTATIONS=host-metrics`. [(Elastic OTel Ref)](#otel_node_disabledenabled_instrumentations-details)
 
 ### `ELASTIC_OTEL_HOST_METRICS_DISABLED` details [elastic_otel_host_metrics_disabled-details]
 
@@ -245,16 +245,16 @@ product:
  edot_node: deprecated X.X.X
 ```
 
-EDOT Node.js collects and exports [host metrics](/reference/edot-node/metrics.md#process-and-runtime-metrics) by default, using the `@opentelemetry/host-metrics` package. To turn off host metrics collection, set the `ELASTIC_HOST_OTEL_METRICS_DISABLED` environment variable to `true`.
+Elastic OTel Node.js collects and exports [host metrics](/reference/edot-node/metrics.md#process-and-runtime-metrics) by default, using the `@opentelemetry/host-metrics` package. To turn off host metrics collection, set the `ELASTIC_HOST_OTEL_METRICS_DISABLED` environment variable to `true`.
 
-Since vX.X.X EDOT Node.js uses the `@opentelemetry/instrumentation-host-metrics` package to collect metrics. This configuration setting is deprecated in favor of using one of the following:
+Since vX.X.X Elastic OTel Node.js uses the `@opentelemetry/instrumentation-host-metrics` package to collect metrics. This configuration setting is deprecated in favor of using one of the following:
 - To turn off the export of all metrics, set the `OTEL_METRICS_EXPORTER` environment variable to `none`.
-- To turn off collection by the `@opentelemetry/instrumentation-host-metrics` package, set the `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` environment variable to exclude that instrumentation. For example, `OTEL_NODE_DISABLED_INSTRUMENTATIONS=host-metrics`. [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details)
+- To turn off collection by the `@opentelemetry/instrumentation-host-metrics` package, set the `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` environment variable to exclude that instrumentation. For example, `OTEL_NODE_DISABLED_INSTRUMENTATIONS=host-metrics`. [(Elastic OTel Ref)](#otel_node_disabledenabled_instrumentations-details)
 
 ### `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` details [otel_exporter_otlp_metrics_temporality_preference-details]
 
 {{es}} and {{kib}} work best with metrics provided in delta-temporality.
-Therefore, the EDOT Node.js changes the default value of `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to `delta`.
+Therefore, Elastic OTel Node.js changes the default value of `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to `delta`.
 You can override this default if needed, note though that some provided {{kib}} dashboards will not work correctly in this case.
 
 OpenTelemetry defaults the temporality preference to `cumulative`. See https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/#additional-environment-variable-configuration
@@ -268,7 +268,7 @@ For Node.js usage, the following instrumentations produce telemetry using HTTP s
 - `@opentelemetry/instrumentation-http`: Currently transitioning from old to stable HTTP semantic conventions, through the `OTEL_SEMCONV_STABILITY_OPT_IN` setting.
 - `@opentelemetry/instrumentation-undici`: Uses the stable HTTP semantic conventions, because this instrumentation was created after HTTP semconv had stabilized.
 
-EDOT Node.js differs from current OTel JS in that it *defaults `OTEL_SEMCONV_STABILITY_OPT_IN` to `http`*. This means that, by default, all HTTP-related telemetry from EDOT Node.js will use the newer, stable HTTP semantic conventions. (This difference from contrib is expected to be temporary, as `@opentelemetry/instrumentation-http` switches to producing only stable HTTP semantic conventions after its transition period.)
+Elastic OTel Node.js differs from current OTel JS in that it *defaults `OTEL_SEMCONV_STABILITY_OPT_IN` to `http`*. This means that, by default, all HTTP-related telemetry from Elastic OTel Node.js will use the newer, stable HTTP semantic conventions. (This difference from contrib is expected to be temporary, as `@opentelemetry/instrumentation-http` switches to producing only stable HTTP semantic conventions after its transition period.)
 
 ### `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` details [elastic_otel_context_propagation_only-details]
 
@@ -288,9 +288,9 @@ product:
   edot_node: preview 1.0.0
 ```
 
-By default EDOT Node.js enables instrumentation for a number of Node.js logging frameworks.
+By default Elastic OTel Node.js enables instrumentation for a number of Node.js logging frameworks.
 Those instrumentations support a feature called "log sending," where log records for any created loggers are sent to the configured OTLP endpoint.
-EDOT Node.js **disables log sending by default.**
+Elastic OTel Node.js **disables log sending by default.**
 To enable log sending, set the `ELASTIC_OTEL_NODE_ENABLE_LOG_SENDING=true` environment variable.
 (Note: The "log correlation" feature of these instrumentations is still enabled by default.)
 

--- a/docs/reference/edot-node/index.md
+++ b/docs/reference/edot-node/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT Node.js
-description: Introduction to the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js).
+navigation_title: Elastic OTel Node.js
+description: Introduction to the Elastic OTel Node.js.
 applies_to:
   stack:
   serverless:
@@ -14,29 +14,29 @@ products:
   - id: apm-agent
 ---
 
-# Elastic Distribution of OpenTelemetry Node.js
+# Elastic OTel Node.js [elastic-distribution-of-opentelemetry-nodejs]
 
-The {{edot}} (EDOT) Node.js is a light wrapper around the [OpenTelemetry SDK for Node.js](https://opentelemetry.io/docs/languages/js), configured for the best experience with Elastic Observability.
+The {{edot}} Node.js is a light wrapper around the [OpenTelemetry SDK for Node.js](https://opentelemetry.io/docs/languages/js), configured for the best experience with Elastic Observability.
 
-Use EDOT Node.js to start the OpenTelemetry SDK with your Node.js application, and automatically capture tracing data, performance metrics, and logs. Traces, metrics, and logs can be sent to any OpenTelemetry Protocol (OTLP) Collector you choose.
+Use Elastic OTel Node.js to start the OpenTelemetry SDK with your Node.js application, and automatically capture tracing data, performance metrics, and logs. Traces, metrics, and logs can be sent to any OpenTelemetry Protocol (OTLP) Collector you choose.
 
 A goal of this distribution is to avoid introducing proprietary concepts in addition to those defined by the wider OpenTelemetry community. For any additional features introduced, Elastic aims at contributing them back to the OpenTelemetry project.
 
 ## Features
 
-In addition to all the features of OpenTelemetry Node.js, with EDOT Node.js you have access to the following:
+In addition to all the features of OpenTelemetry Node.js, with Elastic OTel Node.js you have access to the following:
 
 * A single package that includes several OpenTelemetry packages as dependencies, so you only need to install and update a single package (for most use cases). This is similar to OpenTelemetry's `@opentelemetry/auto-instrumentations-node` package.
 * Improvements and bug fixes contributed by the Elastic team before the changes are available in OpenTelemetry repositories.
 * Optional features that can enhance OpenTelemetry data that is being sent to Elastic.
 * Elastic-specific processors that ensure optimal compatibility when exporting OpenTelemetry signal data to an Elastic backend like an Elastic Observability deployment.
 * Pre-configured collection of tracing and metrics signals, applying some opinionated defaults, such as which sources are collected by default. Additional metrics are collected by default: `process.cpu.*` and `process.memory.*` metrics from the [host-metrics instrumentation package](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-host-metrics/).
-* Compatibility with APM Agent Central Configuration to modify the settings of the EDOT Node.js agent without having to restart the application.
+* Compatibility with APM Agent Central Configuration to modify the settings of the Elastic OTel Node.js SDK without having to restart the application.
 
-Use EDOT Node.js with your Node.js application to automatically capture distributed tracing data, performance metrics, and logs. EDOT Node.js automatically instruments [popular modules](/reference/edot-node/supported-technologies.md#instrumentations) used by your service.
+Use Elastic OTel Node.js with your Node.js application to automatically capture distributed tracing data, performance metrics, and logs. Elastic OTel Node.js automatically instruments [popular modules](/reference/edot-node/supported-technologies.md#instrumentations) used by your service.
 
 Follow the step-by-step instructions in [Setup](/reference/edot-node/setup/index.md) to get started.
 
 ## Release notes
 
-For the latest release notes, including known issues, deprecations, and breaking changes, refer to [EDOT Node.js release notes](/release-notes/index.md)
+For the latest release notes, including known issues, deprecations, and breaking changes, refer to [Elastic OTel Node.js release notes](/release-notes/index.md)

--- a/docs/reference/edot-node/metrics.md
+++ b/docs/reference/edot-node/metrics.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Metrics
-description: Metrics produced by the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js).
+description: Metrics produced by Elastic OTel Node.js.
 applies_to:
   stack:
   serverless:
@@ -15,11 +15,11 @@ products:
 
 # Metrics
 
-In the Elastic Distribution of OpenTelemetry for Node.js (EDOT Node.js) the collection of metrics is turned on by default. Refer to the [settings with `METRIC` in the name](/reference/edot-node/configuration.md) for all options for configuring metric collection.
+In Elastic OTel Node.js the collection of metrics is turned on by default. Refer to the [settings with `METRIC` in the name](/reference/edot-node/configuration.md) for all options for configuring metric collection.
 
 ## Process and runtime metrics
 
-EDOT Node.js gathers metrics from the Node.js process your application is
+Elastic OTel Node.js gathers metrics from the Node.js process your application is
 running using the following packages:
 
 - `@opentelemetry/instrumentation-host-metrics` to gather `process.cpu.*` and `process.memory.*` metrics ([ref](https://github.com/open-telemetry/semantic-conventions/blob/80988c54712ee336cb3a6240b8845e9dfa8c9f49/docs/system/process-metrics.md?plain=1#L22)).
@@ -42,5 +42,5 @@ A subset of them are useful to detect issues when doing an overview of the instr
 - `process.memory.usage` is the value of [Resident Set Size](https://nodejs.org/api/process.html#processmemoryusagerss) in bytes. It
   measures how much memory the process is allocating.
 
-If your service is instrumented by EDOT Node.js, or by custom instrumentation that includes the packages previously mentioned,
+If your service is instrumented by Elastic OTel Node.js, or by custom instrumentation that includes the packages previously mentioned,
 {{kib}} shows them as part of the [service metrics](docs-content://solutions/observability/apm/metrics-ui.md).

--- a/docs/reference/edot-node/migration.md
+++ b/docs/reference/edot-node/migration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Migration
-description: Migrate from the Elastic APM Node.js agent to the Elastic Distribution of OpenTelemetry for Node.js (EDOT Node.js).
+description: Migrate from the Elastic APM Node.js agent to Elastic OTel Node.js.
 applies_to:
   stack:
   serverless:
@@ -14,14 +14,14 @@ products:
   - id: apm-agent
 ---
 
-# Migrate to EDOT Node.js from the Elastic {{product.apm}} Node.js agent
+# Migrate to Elastic OTel Node.js from the Elastic {{product.apm}} Node.js agent [migrate-to-edot-nodejs-from-the-elastic-productapm-nodejs-agent]
 
 Compared to the Elastic {{product.apm}} Node.js agent, the {{edot}} Node.js presents a number of advantages:
 
 - Fully automatic instrumentation with zero code changes. No need to modify application code.
-- EDOT Node.js is built on top of OpenTelemetry SDK and conventions, ensuring compatibility with community tools, vendor-neutral backends, and so on.
+- Elastic OTel Node.js is built on top of OpenTelemetry SDK and conventions, ensuring compatibility with community tools, vendor-neutral backends, and so on.
 - Modular, extensible architecture based on the OpenTelemetry SDK. You can add custom exporters, processors, and samplers.
-- You can use EDOT Node.js in environments where both tracing and metrics are collected using OpenTelemetry.
+- You can use Elastic OTel Node.js in environments where both tracing and metrics are collected using OpenTelemetry.
 
 
 ## Migration steps
@@ -32,7 +32,7 @@ Follow these steps to migrate from the legacy Elastic {{product.apm}} PHP agent 
 
 ::::{step} Replace the Node.js package
 
-Remove the Elastic {{product.apm-agent-node}} package and install EDOT Node.js:
+Remove the Elastic {{product.apm-agent-node}} package and install Elastic OTel Node.js:
 
 ```sh
 npm uninstall elastic-apm-node
@@ -54,12 +54,12 @@ If you're using the [Elastic {{product.apm-agent-node}} API](apm-agent-nodejs://
 ::::
 
 ::::{step} Replace configuration options
-Refer to the [Configuration mapping](#configuration-mapping). Refer to [Configuration](/reference/edot-node/configuration.md) for details on EDOT Node.js configuration.
+Refer to the [Configuration mapping](#configuration-mapping). Refer to [Configuration](/reference/edot-node/configuration.md) for details on Elastic OTel Node.js configuration.
 ::::
 
-::::{step} Add EDOT Node.js start method
+::::{step} Add Elastic OTel Node.js start method
 
-Use the [Node.js `--import` option](https://nodejs.org/api/cli.html#--importmodule) to start EDOT Node.js with your service.
+Use the [Node.js `--import` option](https://nodejs.org/api/cli.html#--importmodule) to start Elastic OTel Node.js with your service.
 
 Set it on the command-line using `node --import @elastic/opentelemetry-node service.js` or in the [`NODE_OPTIONS` environment variable](https://nodejs.org/api/cli.html#node_optionsoptions): `NODE_OPTIONS="--import @elastic/opentelemetry-node" node service.js`.
 ::::
@@ -68,13 +68,13 @@ Set it on the command-line using `node --import @elastic/opentelemetry-node serv
 
 ## Configuration mapping
 
-This list contains Elastic {{product.apm}} Node.js agent configuration options that can be migrated to EDOT Node.js SDK configuration because they have an equivalent in OpenTelemetry.
+This list contains Elastic {{product.apm}} Node.js agent configuration options that can be migrated to Elastic OTel Node.js SDK configuration because they have an equivalent in OpenTelemetry.
 
-### Resource attributes when using the EDOT Collector
+### Resource attributes when using the {{agent}} [resource-attributes-when-using-the-edot-collector]
 
-Ingesting OpenTelemetry data directly through {{product.apm-server}} is [no longer supported](opentelemetry://reference/architecture/index.md#limitations). Historically, when ingesting OpenTelemetry data through the Elastic {{product.apm-server}}, unmapped resource attributes were added under `labels.*`. This behavior does not apply when using the EDOT Collector and is not recommended for new deployments. Use the EDOT Collector or Managed OTLP for supported ingestion.
+Ingesting OpenTelemetry data directly through {{product.apm-server}} is [no longer supported](opentelemetry://reference/architecture/index.md#limitations). Historically, when ingesting OpenTelemetry data through the Elastic {{product.apm-server}}, unmapped resource attributes were added under `labels.*`. This behavior does not apply when using the {{agent}} and is not recommended for new deployments. Use the {{agent}} or Managed OTLP for supported ingestion.
 
-If you rely on specific attribute mappings for querying or filtering in {{product.observability}}, configure explicit attribute processors in the EDOT Collector pipeline.
+If you rely on specific attribute mappings for querying or filtering in {{product.observability}}, configure explicit attribute processors in the {{agent}} pipeline.
 
 ### `active`
 
@@ -96,12 +96,12 @@ For example: `OTEL_EXPORTER_OTLP_HEADERS=foo=bar,baz=quux`.
 
 ### `centralConfig`
 
-The Elastic {{product.apm}} Node.js agent [`centralConfig`](apm-agent-nodejs://reference/configuration.md#central-config) option corresponds to the EDOT Node.js [`ELASTIC_OTEL_OPAMP_ENDPOINT`](/reference/edot-node/configuration.md#configure-central-configuration) option.
+The Elastic {{product.apm}} Node.js agent [`centralConfig`](apm-agent-nodejs://reference/configuration.md#central-config) option corresponds to the Elastic OTel Node.js [`ELASTIC_OTEL_OPAMP_ENDPOINT`](/reference/edot-node/configuration.md#configure-central-configuration) option.
 
 For example: `export ELASTIC_OTEL_OPAMP_ENDPOINT=http://localhost:4320/v1/opamp`.
 
 :::{warning}
-To use central configuration for EDOT Node.js it is necessary to enable it by following the [configuration guide](opentelemetry://reference/central-configuration.md). Also there is a difference in which options can be configured. You can find a list in [central configuration settings](/reference/edot-node/configuration.md#central-configuration-settings).
+To use central configuration for Elastic OTel Node.js it is necessary to enable it by following the [configuration guide](opentelemetry://reference/central-configuration.md). Also there is a difference in which options can be configured. You can find a list in [central configuration settings](/reference/edot-node/configuration.md#central-configuration-settings).
 :::
 
 ### `cloudProvider`
@@ -112,9 +112,9 @@ For example: `OTEL_NODE_RESOURCE_DETECTORS=os,env,host,serviceinstance,process,a
 
 ### `contextPropagationOnly`
 
-The equivalent of the Elastic {{product.apm}} Node.js agent [`contextPropagationOnly`](apm-agent-nodejs://reference/configuration.md#context-propagation-only) option can be accomplished with the following EDOT Node.js settings:
+The equivalent of the Elastic {{product.apm}} Node.js agent [`contextPropagationOnly`](apm-agent-nodejs://reference/configuration.md#context-propagation-only) option can be accomplished with the following Elastic OTel Node.js settings:
 
-- [`ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY=true`](/reference/edot-node/configuration.md#elastic_otel_context_propagation_only-details) to configure trace-context propagation. This turns off sending spans and the overhead from doing so. Using `OTEL_TRACES_EXPORTER=none` turns off context-propagation. The `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` EDOT Node.js setting only impacts tracing, as opposed to the {{product.apm}} agent `contextPropagationOnly` which impacts both tracing and metric collection.
+- [`ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY=true`](/reference/edot-node/configuration.md#elastic_otel_context_propagation_only-details) to configure trace-context propagation. This turns off sending spans and the overhead from doing so. Using `OTEL_TRACES_EXPORTER=none` turns off context-propagation. The `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` Elastic OTel Node.js setting only impacts tracing, as opposed to the {{product.apm}} agent `contextPropagationOnly` which impacts both tracing and metric collection.
 - To turn off metrics sending and collection overhead, use the following settings:
     - [`OTEL_METRICS_EXPORTER=none`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection) to turn off the sending of any metrics.
     - [`OTEL_NODE_DISABLED_INSTRUMENTATIONS=host-metrics`](/reference/edot-node/configuration.md#otel_node_disabledenabled_instrumentations-details) to remove the overhead from metrics collection by the `@opentelemetry/instrumentation-host-metrics` instrumentation.
@@ -130,7 +130,7 @@ OTEL_NODE_DISABLED_INSTRUMENTATIONS=runtime-node,host-metrics
 
 ### `disableInstrumentations`
 
-The Elastic {{product.apm}} Node.js agent [`disableInstrumentations`](apm-agent-nodejs://reference/configuration.md#disable-instrumentations) option corresponds to the EDOT Node.js [`OTEL_NODE_DISABLED_INSTRUMENTATIONS`](/reference/edot-node/configuration.md#otel_node_disabledenabled_instrumentations-details) option.
+The Elastic {{product.apm}} Node.js agent [`disableInstrumentations`](apm-agent-nodejs://reference/configuration.md#disable-instrumentations) option corresponds to the Elastic OTel Node.js [`OTEL_NODE_DISABLED_INSTRUMENTATIONS`](/reference/edot-node/configuration.md#otel_node_disabledenabled_instrumentations-details) option.
 
 For example: `OTEL_NODE_DISABLED_INSTRUMENTATIONS=express,mysql`.
 
@@ -173,10 +173,10 @@ For example: `OTEL_RESOURCE_ATTRIBUTES=host.name=myhost`.
 
 The Elastic {{product.apm}} Node.js agent [`instrument`](apm-agent-nodejs://reference/configuration.md#instrument) option can be achieved with [`OTEL_NODE_ENABLED_INSTRUMENTATIONS`](/reference/edot-node/configuration.md#otel_node_disabledenabled_instrumentations-details) option.
 
-For example: `OTEL_NODE_ENABLED_INSTRUMENTATIONS=none` makes EDOT Node.js instrument no packages. It is equivalent to `instrument=false`.
+For example: `OTEL_NODE_ENABLED_INSTRUMENTATIONS=none` makes Elastic OTel Node.js instrument no packages. It is equivalent to `instrument=false`.
 
 :::{note}
-Because "none" is not an instrumentation name, EDOT Node.js logs a message saying so. The message has the following format:
+Because "none" is not an instrumentation name, Elastic OTel Node.js logs a message saying so. The message has the following format:
 `{"name":"elastic-otel-node","level":40,"msg":"Unknown instrumentation \"none\" specified in environment variable \"OTEL_NODE_ENABLED_INSTRUMENTATIONS\"","time":"2025-09-01T11:12:30.949Z"}`
 :::
 
@@ -184,7 +184,7 @@ Because "none" is not an instrumentation name, EDOT Node.js logs a message sayin
 
 The Elastic {{product.apm}} Node.js agent [`logLevel`](apm-agent-nodejs://reference/configuration.md#log-level) option corresponds to the OpenTelemetry [`OTEL_LOG_LEVEL`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) option.
 
-The following table shows the equivalent values of log levels between `elastic-apm-node` and EDOT Node.js.
+The following table shows the equivalent values of log levels between `elastic-apm-node` and Elastic OTel Node.js.
 
 | ELASTIC_APM_LOG_LEVEL | OTEL_LOG_LEVEL |
 | --------------------- | -------------- |
@@ -246,7 +246,7 @@ The Elastic {{product.apm}} Node.js agent [`serverUrl`](apm-agent-nodejs://refer
 
 - If using {{serverless-full}}, set `OTEL_EXPORTER_OTLP_ENDPOINT` to the [{{motlp}}](opentelemetry://reference/motlp.md) URL for your Serverless project. For example, `OTEL_EXPORTER_OTLP_ENDPOINT=https://my-prj-a1b2c3.ingest.eu-west-1.aws.elastic.cloud`. Refer to the [Quickstart for {{serverless-full}}](docs-content://solutions/observability/get-started/opentelemetry/quickstart/serverless/index.md).
 
-- If using {{ech}} or Self-managed, set `OTEL_EXPORTER_OTLP_ENDPOINT` to the endpoint URL of your EDOT Collector. Refer to the [Quickstart for {{ech}}](docs-content://solutions/observability/get-started/opentelemetry/quickstart/ech/hosts_vms.md) or the [Quickstart for Self-managed](docs-content://solutions/observability/get-started/opentelemetry/quickstart/self-managed/hosts_vms.md).
+- If using {{ech}} or Self-managed, set `OTEL_EXPORTER_OTLP_ENDPOINT` to the endpoint URL of your {{agent}}. Refer to the [Quickstart for {{ech}}](docs-content://solutions/observability/get-started/opentelemetry/quickstart/ech/hosts_vms.md) or the [Quickstart for Self-managed](docs-content://solutions/observability/get-started/opentelemetry/quickstart/self-managed/hosts_vms.md).
 
 ### `serviceName`
 
@@ -274,29 +274,29 @@ For example, for the equivalent of `transactionSampleRate: '0.25'` use `OTEL_TRA
 
 ## Limitations
 
-The following limitations apply to EDOT Node.js.
+The following limitations apply to Elastic OTel Node.js.
 
 ### Supported Node.js versions
 
-EDOT Node.js and OpenTelemetry SDK support Node.js versions in the range `^18.19.0 || >=20.6.0`. Elastic {{product.apm}} Node.js works with Node.js versions `>=14.17.0`, though with limited support for Node.js 14 and 16 given that those major versions of Node.js are out of long-term support.
+Elastic OTel Node.js and OpenTelemetry SDK support Node.js versions in the range `^18.19.0 || >=20.6.0`. Elastic {{product.apm}} Node.js works with Node.js versions `>=14.17.0`, though with limited support for Node.js 14 and 16 given that those major versions of Node.js are out of long-term support.
 
 ### Missing instrumentations
 
-EDOT Node.js doesn't currently support instrumentation for AWS Lambda and Azure Functions. However, there are contrib and third-party options based on OpenTelemetry:
+Elastic OTel Node.js doesn't currently support instrumentation for AWS Lambda and Azure Functions. However, there are contrib and third-party options based on OpenTelemetry:
 
 - For AWS Lambda use [OpenTelemetry Lambda layers](https://github.com/open-telemetry/opentelemetry-lambda).
 - For Azure Functions you can [configure OpenTelemetry](https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto?tabs=app-insights&pivots=programming-language-javascript).
 
 ### Central configuration
 
-You can manage EDOT Node.js configurations through the [central configuration feature](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) in the Applications UI.
+You can manage Elastic OTel Node.js configurations through the [central configuration feature](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) in the Applications UI.
 
 Refer to [Central configuration](opentelemetry://reference/central-configuration.md) for more information.
 
 ### Span compression
 
-EDOT Node.js does not implement [span compression](docs-content://solutions/observability/apm/spans.md#apm-spans-span-compression).
+Elastic OTel Node.js does not implement [span compression](docs-content://solutions/observability/apm/spans.md#apm-spans-span-compression).
 
 ## Troubleshooting
 
-If you're encountering issues during migration, refer to the [EDOT Node.js troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/nodejs/index.md).
+If you're encountering issues during migration, refer to the [Elastic OTel Node.js troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/nodejs/index.md).

--- a/docs/reference/edot-node/setup/index.md
+++ b/docs/reference/edot-node/setup/index.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Setup
-description: How to set up the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js).
+description: How to set up Elastic OTel Node.js.
 applies_to:
   stack:
   serverless:
@@ -13,9 +13,9 @@ products:
   - id: edot-sdk
 ---
 
-# Set up EDOT Node.js
+# Set up Elastic OTel Node.js [set-up-edot-nodejs]
 
-To monitor your service with the {{edot}} (EDOT) Node.js you need to install it, configure it, and properly start it with your application.
+To monitor your service with the {{edot}} Node.js you need to install it, configure it, and properly start it with your application.
 
 For example, the following commands perform the minimal setup steps:
 
@@ -41,11 +41,11 @@ If you are deploying in Kubernetes, see the [Kubernetes setup guide](/reference/
 
 Before getting started, you need somewhere to send the gathered OpenTelemetry data, so it can be viewed and analyzed. This doc assumes you're using an Elastic Observability deployment. You can use an existing one or set up a new one.
 
-Follow the EDOT [Quickstart guide](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md) to get a deployment and gather the `ELASTIC_OTLP_ENDPOINT` and `ELASTIC_API_KEY` pieces of data that you need to configure the EDOT Node.js SDK.
+Follow the [{{edot}} quickstart](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md) to get a deployment and gather the `ELASTIC_OTLP_ENDPOINT` and `ELASTIC_API_KEY` pieces of data that you need to configure the Elastic OTel Node.js SDK.
 
 ## Installation
 
-EDOT Node.js is published to npm as the [`@elastic/opentelemetry-node` package](https://www.npmjs.com/package/@elastic/opentelemetry-node). Install it with your chosen package manager:
+Elastic OTel Node.js is published to npm as the [`@elastic/opentelemetry-node` package](https://www.npmjs.com/package/@elastic/opentelemetry-node). Install it with your chosen package manager:
 
 ```bash
 npm install @elastic/opentelemetry-node  
@@ -55,20 +55,20 @@ pnpm add @elastic/opentelemetry-node
 
 ## Configuration
 
-EDOT Node.js is configured with environment variables beginning with `OTEL_` or `ELASTIC_OTEL_`. Any `OTEL_*` environment variables behave the same as with the OpenTelemetry SDK. 
+Elastic OTel Node.js is configured with environment variables beginning with `OTEL_` or `ELASTIC_OTEL_`. Any `OTEL_*` environment variables behave the same as with the OpenTelemetry SDK. 
 
-For example, all the OpenTelemetry [General SDK Configuration env vars](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) are supported. If EDOT Node.js provides a configuration setting specific to the Elastic distribution, it begins with `ELASTIC_OTEL_`.
+For example, all the OpenTelemetry [General SDK Configuration env vars](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) are supported. If Elastic OTel Node.js provides a configuration setting specific to the Elastic distribution, it begins with `ELASTIC_OTEL_`.
 
 ### Basic configuration
 
-To configure EDOT Node.js, as a typical minimum you need:
+To configure Elastic OTel Node.js, as a typical minimum you need:
 
-* `OTEL_EXPORTER_OTLP_ENDPOINT`: The full URL of an OpenTelemetry Collector where data is sent. When using Elastic Observability, this is the ingest endpoint of an {{serverless-full}} project or the URL of a deployed [EDOT Collector](elastic-agent://reference/edot-collector/index.md). Set this to the `ELASTIC_OTLP_ENDPOINT` value as described in the [EDOT Quickstart pages](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md).
-* `OTEL_EXPORTER_OTLP_HEADERS`: A comma-separated list of HTTP headers used for exporting data, typically used to set the `Authorization` header with auth information. Get an `ELASTIC_API_KEY` as described in the [EDOT Quickstart pages](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md) and set this to `"Authorization=ApiKey ELASTIC_API_KEY"`.
+* `OTEL_EXPORTER_OTLP_ENDPOINT`: The full URL of an OpenTelemetry Collector where data is sent. When using Elastic Observability, this is the ingest endpoint of an {{serverless-full}} project or the URL of a deployed [{{agent}}](elastic-agent://reference/edot-collector/index.md). Set this to the `ELASTIC_OTLP_ENDPOINT` value as described in the [{{edot}} quickstart pages](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md).
+* `OTEL_EXPORTER_OTLP_HEADERS`: A comma-separated list of HTTP headers used for exporting data, typically used to set the `Authorization` header with auth information. Get an `ELASTIC_API_KEY` as described in the [{{edot}} quickstart pages](docs-content://solutions/observability/get-started/opentelemetry/quickstart/index.md) and set this to `"Authorization=ApiKey ELASTIC_API_KEY"`.
 * `OTEL_SERVICE_NAME`: The name of your service, used to distinguish telemetry data from other services in your system. If not set, it defaults to `unknown_service:node`.
 
 :::{note}
-In some environments, for example in some Kubernetes setups, a local OpenTelemetry Collector is deployed with an endpoint of `http://localhost:4318`. This is the default exporter endpoint used by EDOT Node.js. In this case the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable does not need to be set.
+In some environments, for example in some Kubernetes setups, a local OpenTelemetry Collector is deployed with an endpoint of `http://localhost:4318`. This is the default exporter endpoint used by Elastic OTel Node.js. In this case the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable does not need to be set.
 :::
 
 ### Additional configuration
@@ -77,16 +77,16 @@ Additional other common configuration settings that might be useful include:
 
 * `OTEL_RESOURCE_ATTRIBUTES=service.version=<app-version>,deployment.environment.name=production`: This environment variable can be used to set additional [Resource attributes](https://opentelemetry.io/docs/languages/js/resources/). Setting `service.version` can be useful for correlating issues to different versions of your service. Setting `deployment.environment.name` can be useful for separating telemetry for development, test, qa, or production deployments of your services.
 * `OTEL_NODE_DISABLED_INSTRUMENTATIONS=net,dns,...`: A comma-separated list of instrumentation names to disable. This can be useful if a particular instrumentation is unwanted for some reason.
-* `OTEL_LOG_LEVEL=verbose`: This can be used to get more internal logging data from EDOT Node.js when investigating issues with telemetry.
-* `OTEL_SDK_DISABLED=true`: This can be used to fully disable EDOT Node.js, perhaps when troubleshooting.
+* `OTEL_LOG_LEVEL=verbose`: This can be used to get more internal logging data from Elastic OTel Node.js when investigating issues with telemetry.
+* `OTEL_SDK_DISABLED=true`: This can be used to fully disable Elastic OTel Node.js, perhaps when troubleshooting.
 
 For more information on all the available configuration options, refer to [Configuration](/reference/edot-node/configuration.md).
 
-## Start EDOT Node.js
+## Start Elastic OTel Node.js [start-edot-nodejs]
 
-For EDOT Node.js to automatically instrument modules used by your Node.js service, start it before you `require` or `import` your service code's dependencies. For example, before `express` or `http` are loaded.
+For Elastic OTel Node.js to automatically instrument modules used by your Node.js service, start it before you `require` or `import` your service code's dependencies. For example, before `express` or `http` are loaded.
 
-The recommended way to start EDOT Node.js is by using the `--import` Node.js [CLI option](https://nodejs.org/api/cli.html#--importmodule). This loads and starts the SDK in Node.js' "preload" phase, which ensures that it is started before any application modules.
+The recommended way to start Elastic OTel Node.js is by using the `--import` Node.js [CLI option](https://nodejs.org/api/cli.html#--importmodule). This loads and starts the SDK in Node.js' "preload" phase, which ensures that it is started before any application modules.
 
 ```sh
 node --import @elastic/opentelemetry-node my-app.js
@@ -99,18 +99,18 @@ export NODE_OPTIONS="--import @elastic/opentelemetry-node"
 node my-app.js
 ```
 
-EDOT Node.js automatically instruments popular modules, listed in [Supported technologies](/reference/edot-node/supported-technologies.md), used by your service, and send traces, metrics, and logs telemetry data (using OTLP) to your configured observability backend.
+Elastic OTel Node.js automatically instruments popular modules, listed in [Supported technologies](/reference/edot-node/supported-technologies.md), used by your service, and send traces, metrics, and logs telemetry data (using OTLP) to your configured observability backend.
 
 ## Confirm instrumentation is working
 
-To confirm that EDOT Node.js has be setup successfully:
+To confirm that Elastic OTel Node.js has been set up successfully:
 
-1. Call your running service to ensure it has had some activity that EDOT Node.js can trace.
+1. Call your running service to ensure it has had some activity that Elastic OTel Node.js can trace.
 2. Go to **Applications** → **Service Inventory** in your Elastic Observability deployment.
-3. Find the name of your service. It can take a minute or two after starting your service with EDOT Node.js for the service to show up in this list.
+3. Find the name of your service. It can take a minute or two after starting your service with Elastic OTel Node.js for the service to show up in this list.
 
 If you do not see your service, work through [the Troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/nodejs/index.md).
 
 ## Troubleshooting
 
-For help with common setup issues, refer to the [EDOT Node.js troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/nodejs/index.md).
+For help with common setup issues, refer to the [Elastic OTel Node.js troubleshooting guide](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/nodejs/index.md).

--- a/docs/reference/edot-node/setup/k8s.md
+++ b/docs/reference/edot-node/setup/k8s.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Kubernetes
-description: How to instrument Node.js applications on Kubernetes using the Elastic Distribution of OpenTelemetry (EDOT).
+description: How to instrument Node.js applications on Kubernetes using Elastic OpenTelemetry.
 applies_to:
   stack:
   serverless:
@@ -13,11 +13,11 @@ products:
   - id: edot-sdk
 ---
 
-# Instrumenting Node.js applications with EDOT SDKs on Kubernetes
+# Instrumenting Node.js applications with Elastic OTel SDKs on Kubernetes [instrumenting-nodejs-applications-with-edot-sdks-on-kubernetes]
 
-Learn how to instrument Node.js applications on Kubernetes, using the OpenTelemetry Operator, the {{edot}} (EDOT) Collectors, and the EDOT Node.js SDK.
+Learn how to instrument Node.js applications on Kubernetes, using the OpenTelemetry Operator, the {{edot}} Collectors, and the Elastic OTel Node.js SDK.
 
-- For general knowledge about the EDOT Node.js SDK, refer to the [EDOT Node.js Intro page](/reference/edot-node/index.md) and [Configuration](/reference/edot-node/configuration.md).
+- For general knowledge about the Elastic OTel Node.js SDK, refer to the [Elastic OTel Node.js intro page](/reference/edot-node/index.md) and [Configuration](/reference/edot-node/configuration.md).
 - For Node.js auto-instrumentation specifics, refer to [OpenTelemetry Operator Node.js auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#nodejs).
 - For general information about instrumenting applications on Kubernetes, refer to [instrumenting applications on Kubernetes](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/instrumenting-applications.md).
 

--- a/docs/reference/edot-node/supported-technologies.md
+++ b/docs/reference/edot-node/supported-technologies.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Supported Technologies
-description: Supported technologies for the Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js).
+description: Supported technologies for Elastic OTel Node.js.
 applies_to:
   stack:
   serverless:
@@ -13,9 +13,9 @@ products:
   - id: edot-sdk
 ---
 
-# Technologies supported by the EDOT Node.js SDK
+# Technologies supported by the Elastic OTel Node.js SDK [technologies-supported-by-the-edot-nodejs-sdk]
 
-The EDOT Node.js agent is a [distribution](https://opentelemetry.io/docs/concepts/distributions/) of OpenTelemetry Node.js. It inherits all the [supported](opentelemetry://reference/compatibility/nomenclature.md) technologies of the OpenTelemetry Node.js.
+The Elastic OTel Node.js agent is a [distribution](https://opentelemetry.io/docs/concepts/distributions/) of OpenTelemetry Node.js. It inherits all the [supported](opentelemetry://reference/compatibility/nomenclature.md) technologies of the OpenTelemetry Node.js.
 
 :::{note}
 **Understanding auto-instrumentation scope**
@@ -32,19 +32,19 @@ If your application uses technologies not covered by auto-instrumentation, you h
 2. **Manual instrumentation** — Use the [OpenTelemetry API](https://opentelemetry.io/docs/languages/js/instrumentation/) to add custom spans, metrics, and logs for unsupported components.
 :::
 
-## EDOT Collector and Elastic Stack versions
+## {{agent}} and {{stack}} versions [edot-collector-and-elastic-stack-versions]
 
-The {{edot}} Node.js (EDOT Node.js) sends data through the OpenTelemetry protocol (OTLP). While OTLP ingest works with later 8.16+ versions of the EDOT Collector, for full support use either [EDOT Collector](elastic-agent://reference/edot-collector/index.md) versions 9.x or [{{serverless-full}}](docs-content://deploy-manage/deploy/elastic-cloud/serverless.md) for OTLP ingest.
+The {{edot}} Node.js sends data through the OpenTelemetry protocol (OTLP). While OTLP ingest works with later 8.16+ versions of the {{agent}}, for full support use either [{{agent}}](elastic-agent://reference/edot-collector/index.md) versions 9.x or [{{serverless-full}}](docs-content://deploy-manage/deploy/elastic-cloud/serverless.md) for OTLP ingest.
 
 :::{note}
-Ingesting data from EDOT SDKs through EDOT Collector 9.x into Elastic Stack versions 8.18+ is supported.
+Ingesting data from Elastic OTel SDKs through {{agent}} 9.x into {{stack}} versions 8.18+ is supported.
 :::
 
-Refer to [EDOT SDKs compatibility](opentelemetry://reference/compatibility/sdks.md) for support details.
+Refer to [Elastic OTel SDKs compatibility](opentelemetry://reference/compatibility/sdks.md) for support details.
 
 ## Node.js versions
 
-EDOT Node.js supports Node.js 18.19.0, 20.6.0, or later. This follows from the [OpenTelemetry JS supported runtimes](https://github.com/open-telemetry/opentelemetry-js#supported-runtimes).
+Elastic OTel Node.js supports Node.js 18.19.0, 20.6.0, or later. This follows from the [OpenTelemetry JS supported runtimes](https://github.com/open-telemetry/opentelemetry-js#supported-runtimes).
 
 ## TypeScript versions
 
@@ -55,9 +55,9 @@ Usage of `@elastic/opentelemetry-node` in TypeScript code requires:
 
 ## Instrumentations [instrumentations]
 
-The following instrumentations are included in EDOT Node.js. All are turned on by default, except those noted _disabled by default_.
+The following instrumentations are included in Elastic OTel Node.js. All are turned on by default, except those noted _disabled by default_.
 
-The 🔹 symbol marks instrumentations that differ between EDOT Node.js and OTel JS, or that only exist in EDOT Node.js.
+The 🔹 symbol marks instrumentations that differ between Elastic OTel Node.js and OTel JS, or that only exist in Elastic OTel Node.js.
 
 | Name | Packages instrumented | Notes |
 |---|---|---|
@@ -104,7 +104,7 @@ The 🔹 symbol marks instrumentations that differ between EDOT Node.js and OTel
 
 ### LLM instrumentations
 
-EDOT Node.js can instrument the following Large Language Model (LLM) libraries with instrumentations implementing the [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
+Elastic OTel Node.js can instrument the following Large Language Model (LLM) libraries with instrumentations implementing the [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
 
 | SDK    | Instrumentation | Traces | Metrics | Logs | Notes |
 |--------|-----------------|--------|---------|------|-------|
@@ -114,7 +114,7 @@ EDOT Node.js can instrument the following Large Language Model (LLM) libraries w
 
 ### Deactivated instrumentations [disabled-instrumentations]
 
-The following instrumentations are included in EDOT Node.js, but deactivated by default:
+The following instrumentations are included in Elastic OTel Node.js, but deactivated by default:
 
 - `@opentelemetry/instrumentation-fs` (Deactivated upstream in [open-telemetry/opentelemetry-js-contrib#2467](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2467).)
 - `@opentelemetry/instrumentation-fastify` (Deprecated upstream and slated for removal. Refer to [open-telemetry/opentelemetry-js-contrib#2652](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2652))
@@ -129,11 +129,11 @@ export OTEL_NODE_ENABLED_INSTRUMENTATIONS="fs,http,fastify" # only the ones in t
 node --import @elastic/opentelemetry-node my-service.js
 ```
 
-EDOT Node.js uses the [`@opentelemetry/auto-instrumentations-node` package set of instrumentations](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/metapackages/auto-instrumentations-node/README.md#supported-instrumentations) as a guide for instrumentations to include, exclude, or turn off by default. This is to maximize compatibility between usage of EDOT Node.js and the OpenTelemetry JS SDK.
+Elastic OTel Node.js uses the [`@opentelemetry/auto-instrumentations-node` package set of instrumentations](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/metapackages/auto-instrumentations-node/README.md#supported-instrumentations) as a guide for instrumentations to include, exclude, or turn off by default. This is to maximize compatibility between usage of Elastic OTel Node.js and the OpenTelemetry JS SDK.
 
 ## Native instrumentations
 
-Native instrumentation refers to OpenTelemetry instrumentation that is built into a library. When a library includes native OTel instrumentation, it provides telemetry data to providers registered by a running OTel SDK. Native instrumentations of note are listed in the following table. To benefit from these instrumentations you only need to use the library and start the EDOT Node.js SDK:
+Native instrumentation refers to OpenTelemetry instrumentation that is built into a library. When a library includes native OTel instrumentation, it provides telemetry data to providers registered by a running OTel SDK. Native instrumentations of note are listed in the following table. To benefit from these instrumentations you only need to use the library and start the Elastic OTel Node.js SDK:
 
 ```bash
 node --import @elastic/opentelemetry-node my-app.js
@@ -145,7 +145,7 @@ node --import @elastic/opentelemetry-node my-app.js
 
 ## ECMAScript Modules (ESM)
 
-EDOT Node.js includes limited and experimental support for instrumenting [ECMAScript module (ESM) imports](https://nodejs.org/api/esm.html#modules-ecmascript-modules). For example modules that are loaded through `import ...` statements and `import('...')` (dynamic import).
+Elastic OTel Node.js includes limited and experimental support for instrumenting [ECMAScript module (ESM) imports](https://nodejs.org/api/esm.html#modules-ecmascript-modules). For example modules that are loaded through `import ...` statements and `import('...')` (dynamic import).
 
 To activate ESM instrumentation, use `node --import @elastic/opentelemetry-node ...` to start the SDK. Using `node --require @elastic/opentelemetry-node ...` does not turn on ESM instrumentation. It is intended to signal that only CommonJS module usage should be instrumented.
 

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Breaking changes
-description: Breaking changes for Elastic Distribution of OpenTelemetry Node.js.
+description: Breaking changes for Elastic OTel Node.js.
 applies_to:
   stack:
   serverless:
@@ -11,9 +11,9 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Node.js breaking changes [edot-nodejs-breaking-changes]
+# Elastic OTel Node.js breaking changes [edot-nodejs-breaking-changes]
 
-Breaking changes can impact your Elastic applications, potentially disrupting normal operations. Before you upgrade, carefully review the Elastic Distribution of OpenTelemetry  breaking changes and take the necessary steps to mitigate any issues.
+Breaking changes can impact your Elastic applications, potentially disrupting normal operations. Before you upgrade, carefully review the Elastic OTel Node.js breaking changes and take the necessary steps to mitigate any issues.
 
 % ## Next version [edot-node-X.X.X-breaking-changes]
 

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Deprecations 
-description: Deprecations for Elastic Distribution of OpenTelemetry Node.js.
+description: Deprecations for Elastic OTel Node.js.
 applies_to:
   stack:
   serverless:
@@ -11,11 +11,11 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Node.js deprecations [edot-nodejs-deprecations]
+# Elastic OTel Node.js deprecations [edot-nodejs-deprecations]
 
 Over time, certain Elastic functionality becomes outdated and is replaced or removed. To help with the transition, Elastic deprecates functionality for a period before removal, giving you time to update your applications.
 
-Review the deprecated functionality for Elastic Distribution of OpenTelemetry Node.js. While deprecations have no immediate impact, we strongly encourage you update your implementation after you upgrade. To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrade.md).
+Review the deprecated functionality for Elastic OTel Node.js. While deprecations have no immediate impact, we strongly encourage you update your implementation after you upgrade. To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrade.md).
 
 % ## Next version [edot-node-X.X.X-deprecations]
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT Node.js
-description: Release notes for Elastic Distribution of OpenTelemetry Node.js.
+navigation_title: Elastic OTel Node.js
+description: Release notes for Elastic OTel Node.js.
 applies_to:
   stack:
   serverless:
@@ -11,11 +11,11 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Node.js release notes [edot-nodejs-release-notes]
+# Elastic OTel Node.js release notes [edot-nodejs-release-notes]
 
-Review the changes, fixes, and more in each version of Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js).
+Review the changes, fixes, and more in each version of Elastic OTel Node.js.
 
-To check for breaking changes, see [EDOT Node.js Breaking Changes](./breaking-changes.md).
+To check for breaking changes, see [Elastic OTel Node.js Breaking Changes](./breaking-changes.md).
 
 To check for security updates, go to [Security announcements for the Elastic stack](https://discuss.elastic.co/c/announcements/security-announcements/31).
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Known issues 
-description: Known issues for Elastic Distribution of OpenTelemetry Node.js.
+description: Known issues for Elastic OTel Node.js.
 applies_to:
   stack:
   serverless:
@@ -11,6 +11,6 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Node.js known issues
+# Elastic OTel Node.js known issues [elastic-distribution-of-opentelemetry-nodejs-known-issues]
 
 No known issues.


### PR DESCRIPTION
## Summary

- Prose-only rebrand across all docs pages under `docs/`: replaces "EDOT Node.js", "EDOT SDK/SDKs", "EDOT Collector", "Elastic Distribution of OpenTelemetry Node.js" and related forms with the new brand names ("Elastic OTel Node.js", "Elastic OTel SDK/SDKs", "{{agent}}", "Elastic OpenTelemetry", etc.).
- Machine identifiers are **unchanged**: env var names, package names, URL path slugs (`edot-node/`), `applies_to` product IDs (`edot-node`, `edot-collector`), and code-block technical values are all preserved.
- Release-note entries for pre-9.5 SDK versions are preserved as-is (historical record).
- All renamed headings have explicit anchors added so existing deep-link slugs continue to resolve (e.g. `[set-up-edot-nodejs]`, `[edot-configuration-details]`).
- `docset.yml` `edot` sub updated: `"Elastic Distribution of OpenTelemetry"` → `"Elastic OpenTelemetry"`.

## Files touched (12)

`docs/docset.yml`, `docs/reference/edot-node/index.md`, `docs/reference/edot-node/configuration.md`, `docs/reference/edot-node/metrics.md`, `docs/reference/edot-node/migration.md`, `docs/reference/edot-node/setup/index.md`, `docs/reference/edot-node/setup/k8s.md`, `docs/reference/edot-node/supported-technologies.md`, `docs/release-notes/index.md`, `docs/release-notes/breaking-changes.md`, `docs/release-notes/deprecations.md`, `docs/release-notes/known-issues.md`

## Held as draft

This PR is held as a **draft** for coordinated merge on **July 28 2026** alongside the 9.5 GA release.

## Test plan

- [ ] Verify no `EDOT` prose remains outside `release-notes/` by running `grep -r "EDOT" docs/ --include="*.md" --include="*.yml" | grep -v "release-notes/"`
- [ ] Confirm URL slugs and `applies_to` product IDs are unchanged
- [ ] Build docs locally and check renamed headings still render with correct anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)