### PR TITLE
chore(deps-dev): force-bump adm-zip for a vuln

### DIFF
--- a/packages/opentelemetry-node/package-lock.json
+++ b/packages/opentelemetry-node/package-lock.json
@@ -3576,13 +3576,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -176,5 +176,11 @@
     "tedious": "^20.0.0",
     "undici": "^6.21.3",
     "winston": "^3.13.1"
+  },
+  "// overrides": "adm-zip: waiting for cassandra-driver release with https://github.com/apache/cassandra-nodejs-driver/pull/470#issuecomment-5211268924",
+  "overrides": {
+    "cassandra-driver": {
+      "adm-zip": "~0.6.0"
+    }
   }
 }


### PR DESCRIPTION
This is anticipating a new cassandra-driver release with the same adm-zip bump
https://github.com/apache/cassandra-nodejs-driver/pull/470#issuecomment-5211268924

This is only used in testing, so this doesn't impact users of this
package.
